### PR TITLE
Add an optional maximum number of opened tabs

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -84,6 +84,7 @@ class TabBarView extends View
     else
       @append(tab)
     tab.updateTitle()
+    @closeOverflowingTabs()
 
   removeTabForItem: (item) ->
     @tabForItem(item).remove()
@@ -102,6 +103,7 @@ class TabBarView extends View
     if tabView? and not tabView.hasClass('active')
       @find(".tab.active").removeClass('active')
       tabView.addClass('active')
+      tabView.updateActivationIndex()
 
   updateActiveTab: ->
     @setActiveTab(@tabForItem(@pane.activeItem))
@@ -241,3 +243,11 @@ class TabBarView extends View
   getTabBar: (target) ->
     target = $(target)
     if target.is('.tab-bar') then target else target.parents('.tab-bar')
+
+  closeOverflowingTabs: ()->
+    maxTabs = atom.config.getInt 'tabs.maximumOpenedTabs' ? Infinity
+    @closeLastActivatedTab() while @getTabs().length > maxTabs
+
+  closeLastActivatedTab: ()->
+    lastOpenedTab = _.min @getTabs(), (tab)-> tab.activationIndex
+    @closeTab lastOpenedTab

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -3,6 +3,7 @@ path = require 'path'
 
 module.exports =
 class TabView extends View
+  @activationCounter = 0
   @content: ->
     @li class: 'tab sortable', =>
       @div class: 'title', outlet: 'title'
@@ -59,3 +60,6 @@ class TabView extends View
     else
       @removeClass('modified') if @isModified
       @isModified = false
+
+  updateActivationIndex: ()->
+    @activationIndex = TabView.activationCounter++

--- a/lib/tabs.coffee
+++ b/lib/tabs.coffee
@@ -2,6 +2,8 @@ _ = require 'underscore-plus'
 TabBarView = require './tab-bar-view'
 
 module.exports =
+  configDefaults:
+    maximumOpenedTabs: null
   activate: ->
     @paneSubscription = atom.workspaceView.eachPane (pane) =>
       tabBarView = new TabBarView(pane)

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -391,3 +391,31 @@ describe "TabBarView", ->
 
         tabBar.dblclick()
         expect(newFileHandler.callCount).toBe 1
+
+    describe "when a maximum tabs number is set", ->
+      beforeEach ()-> atom.config.set 'tabs.maximumOpenedTabs', 4
+      afterEach ()-> atom.config.set 'tabs.maximumOpenedTabs', null
+      it "allow tabs to be added below limit", ()->
+        expect(tabBar.find('.tab').length).toBe 3
+        item3 = new TestView('Item 3')
+        pane.showItem(item3)
+        expect(tabBar.find('.tab').length).toBe 4
+      it "restrains the number of tabs below limit, removing the latest activated", ()->
+        item3 = new TestView('Item 3')
+
+        pane.showItem item1 # -> should be closed
+        pane.showItem item2
+        pane.showItem item3
+        pane.showItem editor1
+
+        expect(tabBar.find('.tab').length).toBe 4
+        expect(tabBar.find('.tab:contains(Item 1)')).toExist()
+        expect(tabBar.find('.tab:contains(Item 2)')).toExist()
+
+        item4 = new TestView('Item 4')
+        pane.showItem(item3)
+        pane.showItem(item4)
+        expect(tabBar.find('.tab').length).toBe 4
+        expect(tabBar.find('.tab:contains(Item 1)')).not.toExist()
+        expect(tabBar.find('.tab:contains(Item 2)')).toExist()
+        expect(tabBar.find('.tab:contains(Item 4)')).toExist()


### PR DESCRIPTION
Hey guys,

I was in love with ST [ZenTabs plugin](https://github.com/travmik/ZenTabs).

The behavior is pretty simple: if there is more tabs than the maximum allowed, close the latest activated tab.

I just added this feature to atom/tabs. The PR comes with tests, just tell me if it isn't enough.

See it running:

![tabs](http://i.imgur.com/tjjvgpc.gif)
