### PR TITLE
Add tabs:toggle command for toggling the Tab Bar

### DIFF
--- a/keymaps/tabs.cson
+++ b/keymaps/tabs.cson
@@ -1,0 +1,2 @@
+'.platform-darwin':
+  'cmd-ctrl-t': 'tabs:toggle'

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -8,6 +8,9 @@ class TabBarView extends View
     @ul tabindex: -1, class: "list-inline tab-bar inset-panel"
 
   initialize: (@pane) ->
+    atom.workspaceView.command 'tabs:toggle', ->
+      atom.workspaceView.find('.tab-bar').toggleClass('hidden')
+
     @command 'tabs:close-tab', => @closeTab()
     @command 'tabs:close-other-tabs', => @closeOtherTabs()
     @command 'tabs:close-tabs-to-right', => @closeTabsToRight()

--- a/menus/tabs.cson
+++ b/menus/tabs.cson
@@ -1,5 +1,19 @@
+'menu': [
+  {
+    'label': 'View'
+    'submenu': [
+      {
+        'label': 'Toggle Tab Bar'
+        'command': 'tabs:toggle'
+      }
+    ]
+  }
+]
+
 'context-menu':
   '.tab':
     'Close Tab': 'tabs:close-tab'
     'Close Other Tabs': 'tabs:close-other-tabs'
     'Close Tabs to the Right': 'tabs:close-tabs-to-right'
+  '.tab-bar':
+    'Hide Tab Bar': 'tabs:toggle'

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -71,6 +71,13 @@ describe "TabBarView", ->
     it "highlights the tab for the active pane item", ->
       expect(tabBar.find('.tab:eq(2)')).toHaveClass 'active'
 
+  describe "when tabs:toggle is triggered", ->
+    it "shows and hides the tab bar", ->
+      atom.workspaceView.trigger 'tabs:toggle'
+      expect(tabBar).toBeHidden
+      atom.workspaceView.trigger 'tabs:toggle'
+      expect(tabBar).toBeVisible
+
   describe "when the active pane item changes", ->
     it "highlights the tab for the new active pane item", ->
       pane.showItem(item1)


### PR DESCRIPTION
I've added the ability to toggle the visibility of the Tab Bar with cmd-ctrl-t by default, or the 'tabs: toggle' command.  I used toggleClass('visible') so that it could be animated easily via css, but left it as a simple toggle as a base. 

![toggle-tabs](https://f.cloud.github.com/assets/230391/2338043/d1d8ba12-a4a4-11e3-9c1a-9d8fd71fd597.gif)
