### PR TITLE
Use default cursor for close-icon instead of pointer

### DIFF
--- a/stylesheets/tabs.less
+++ b/stylesheets/tabs.less
@@ -33,7 +33,7 @@
       position: absolute;
       top: 1px;
       right: 10px;
-      cursor: pointer;
+      cursor: default;
     }
 
     &.modified:hover .close-icon {


### PR DESCRIPTION
**Reasoning:**

Showing the cursor as a "hand" when hovering over things in the UI is a very "web" oriented convention. On an interface that is trying to appear native, it's important that the experience is consistent with the rest of the user's operating system. In OSX, almost no interface elements feature the cursor.

Lastly, closing tabs _feels_ a lot faster after this change.

Before:

![screenshot 2014-03-07 10 42 21](https://f.cloud.github.com/assets/1610503/2359465/0be06e20-a618-11e3-9185-fd0edc65720c.png)

After: 

![screenshot 2014-03-07 10 41 29](https://f.cloud.github.com/assets/1610503/2359470/11a0cc56-a618-11e3-8870-6f2c205bb26b.png)
