### PR TITLE
Bugfixing focus on tab change

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -50,6 +50,7 @@ class TabBarView extends View
       else if which is 1 and not target.classList.contains('close-icon')
         @pane.showItem(tab.item)
         @pane.focus()
+      false
 
     @on 'dblclick', ({target}) =>
       if target is @[0]


### PR DESCRIPTION
As said in issue #28 and [here on discourse](http://discuss.atom.io/t/focus-to-the-editor-when-changing-tab-by-clicking-on-it/3793), when clicking on a tab, the focus doesn't pass to the content of the tab.

After some investigations, it appears to be a missing return value for an handler.
