### PR TITLE
add close unmodified context menu

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -11,6 +11,8 @@ class TabBarView extends View
     @command 'tabs:close-tab', => @closeTab()
     @command 'tabs:close-other-tabs', => @closeOtherTabs()
     @command 'tabs:close-tabs-to-right', => @closeTabsToRight()
+    @command 'tabs:close-saved-tabs', => @closeSavedTabs()
+    @command 'tabs:close-all-tabs', => @closeAllTabs()
 
     @on 'dragstart', '.sortable', @onDragStart
     @on 'dragend', '.sortable', @onDragEnd
@@ -124,6 +126,14 @@ class TabBarView extends View
     index = tabs.indexOf(active)
     return if index is -1
     @closeTab tab for tab, i in tabs when i > index
+
+  closeSavedTabs: ->
+    tabs = @getTabs()
+    @closeTab tab for tab in tabs when not tab.item.isModified()
+
+  closeAllTabs: ->
+    tabs = @getTabs()
+    @closeTab tab for tab in tabs
 
   shouldAllowDrag: ->
     (@paneContainer.getPanes().length > 1) or (@pane.getItems().length > 1)

--- a/menus/tabs.cson
+++ b/menus/tabs.cson
@@ -3,3 +3,5 @@
     'Close Tab': 'tabs:close-tab'
     'Close Other Tabs': 'tabs:close-other-tabs'
     'Close Tabs to the Right': 'tabs:close-tabs-to-right'
+    'Close Saved Tabs': 'tabs:close-saved-tabs'
+    'Close All Tabs': 'tabs:close-all-tabs'


### PR DESCRIPTION
My common workflow is poking around in a bunch of other files to figure something out and then want to get back and focus only on what I've changed.
![close-unmodified](https://cloud.githubusercontent.com/assets/868298/2558729/a3fac5ca-b757-11e3-8981-1798214dee76.gif)
