### PR TITLE
Octicon-based favicons for tabs

### DIFF
--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -20,6 +20,8 @@ class TabView extends View
     @item.on? 'modified-status-changed', =>
       @updateModifiedStatus()
 
+    @subscribe atom.config.observe 'tabs.showIcons', => @updateIconVisibility()
+
     @updateTitle()
     @updateIcon()
     @updateModifiedStatus()
@@ -63,6 +65,12 @@ class TabView extends View
 
   getSiblingTabs: ->
     @siblings('.tab').views()
+
+  updateIconVisibility: ->
+    if atom.config.get "tabs.showIcons"
+      @title.removeClass("hide-icon")
+    else
+      @title.addClass("hide-icon")
 
   updateModifiedStatus: ->
     if @item.isModified?()

--- a/lib/tabs.coffee
+++ b/lib/tabs.coffee
@@ -2,6 +2,9 @@ _ = require 'underscore-plus'
 TabBarView = require './tab-bar-view'
 
 module.exports =
+  configDefaults:
+    showIcons: true
+
   activate: ->
     @paneSubscription = atom.workspaceView.eachPaneView (paneView) =>
       tabBarView = new TabBarView(paneView)

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -177,35 +177,82 @@ describe "TabBarView", ->
       expect(tabBar.tabForItem(item1)).toHaveText "Grumpy Old Man"
       expect(tabBar.tabForItem(item2)).toHaveText "Old Man"
 
-    describe "when an item has an icon defined", ->
-      it "displays the icon on the tab", ->
-        expect(tabBar.find('.tab:eq(0) .title')).toHaveClass "icon"
-        expect(tabBar.find('.tab:eq(0) .title')).toHaveClass "icon-squirrel"
+  describe "when an item has an icon defined", ->
+    it "displays the icon on the tab", ->
+      expect(tabBar.find('.tab:eq(0) .title')).toHaveClass "icon"
+      expect(tabBar.find('.tab:eq(0) .title')).toHaveClass "icon-squirrel"
 
-      it "hides the icon from the tab if the icon removed", ->
-        item1.getIconName = null
-        item1.trigger 'icon-changed'
-        expect(tabBar.find('.tab:eq(0) .title')).not.toHaveClass "icon"
-        expect(tabBar.find('.tab:eq(0) .title')).not.toHaveClass "icon-squirrel"
+    it "hides the icon from the tab if the icon is removed", ->
+      item1.getIconName = null
+      item1.trigger 'icon-changed'
+      expect(tabBar.find('.tab:eq(0) .title')).not.toHaveClass "icon"
+      expect(tabBar.find('.tab:eq(0) .title')).not.toHaveClass "icon-squirrel"
 
-      it "updates the icon on the tab if the icon is changed", ->
-        item1.getIconName = ->
-          "zap"
-        item1.trigger 'icon-changed'
-        expect(tabBar.find('.tab:eq(0) .title')).toHaveClass "icon"
-        expect(tabBar.find('.tab:eq(0) .title')).toHaveClass "icon-zap"
+    it "updates the icon on the tab if the icon is changed", ->
+      item1.getIconName = ->
+        "zap"
+      item1.trigger 'icon-changed'
+      expect(tabBar.find('.tab:eq(0) .title')).toHaveClass "icon"
+      expect(tabBar.find('.tab:eq(0) .title')).toHaveClass "icon-zap"
 
-    describe "when the item doesn't have an icon defined", ->
-      it "doesn't display an icon on the tab", ->
-        expect(tabBar.find('.tab:eq(2) .title')).not.toHaveClass "icon"
-        expect(tabBar.find('.tab:eq(2) .title')).not.toHaveClass "icon-squirrel"
+    describe "when showIcon is set to true in package settings", ->
+      beforeEach ->
+        spyOn(tabBar.tabForItem(item1), 'updateIconVisibility').andCallThrough()
 
-      it "shows the icon on the tab if an icon is added", ->
-        item2.getIconName = ->
-          "squirrel"
-        item2.trigger 'icon-changed'
-        expect(tabBar.find('.tab:eq(2) .title')).toHaveClass "icon"
-        expect(tabBar.find('.tab:eq(2) .title')).toHaveClass "icon-squirrel"
+        atom.config.set("tabs.showIcons", true)
+
+        waitsFor ->
+          tabBar.tabForItem(item1).updateIconVisibility.callCount > 0
+
+        runs ->
+          tabBar.tabForItem(item1).updateIconVisibility.reset()
+
+      it "doesn't hide the icon", ->
+        expect(tabBar.find('.tab:eq(0) .title')).not.toHaveClass "hide-icon"
+
+      it "hides the icon from the tab when showIcon is changed to false", ->
+        atom.config.set("tabs.showIcons", false)
+
+        waitsFor ->
+          tabBar.tabForItem(item1).updateIconVisibility.callCount > 0
+
+        runs ->
+          expect(tabBar.find('.tab:eq(0) .title')).toHaveClass "hide-icon"
+
+    describe "when showIcon is set to false in package settings", ->
+      beforeEach ->
+        spyOn(tabBar.tabForItem(item1), 'updateIconVisibility').andCallThrough()
+
+        atom.config.set("tabs.showIcons", false)
+
+        waitsFor ->
+          tabBar.tabForItem(item1).updateIconVisibility.callCount > 0
+
+        runs ->
+          tabBar.tabForItem(item1).updateIconVisibility.reset()
+
+      it "hides the icon", ->
+        expect(tabBar.find('.tab:eq(0) .title')).toHaveClass "hide-icon"
+
+      it "shows the icon on the tab when showIcon is changed to true", ->
+        atom.config.set("tabs.showIcons", true)
+
+        waitsFor ->
+          tabBar.tabForItem(item1).updateIconVisibility.callCount > 0
+
+        expect(tabBar.find('.tab:eq(0) .title')).not.toHaveClass "hide-icon"
+
+  describe "when the item doesn't have an icon defined", ->
+    it "doesn't display an icon on the tab", ->
+      expect(tabBar.find('.tab:eq(2) .title')).not.toHaveClass "icon"
+      expect(tabBar.find('.tab:eq(2) .title')).not.toHaveClass "icon-squirrel"
+
+    it "shows the icon on the tab if an icon is defined", ->
+      item2.getIconName = ->
+        "squirrel"
+      item2.trigger 'icon-changed'
+      expect(tabBar.find('.tab:eq(2) .title')).toHaveClass "icon"
+      expect(tabBar.find('.tab:eq(2) .title')).toHaveClass "icon-squirrel"
 
   describe "when a tab item's modified status changes", ->
     it "adds or removes the 'modified' class to the tab based on the status", ->

--- a/stylesheets/tabs.less
+++ b/stylesheets/tabs.less
@@ -28,6 +28,12 @@
       text-overflow: ellipsis;
     }
 
+    .hide-icon {
+      &.icon:before {
+        display: none;
+      }
+    }
+
     .close-icon {
       .octicon(x, @close-icon-size);
       position: absolute;


### PR DESCRIPTION
While playing with https://github.com/atom/settings-view/issues/80 today, I though it might be :cool: to have a simple way to add octicons to tabs (as favicons):

![screen shot 2014-04-26 at 9 53 27 pm](https://cloud.githubusercontent.com/assets/38924/2809673/8167a52e-cd7c-11e3-94b1-36ff9493e0b4.png)

For example, those would be helpful when looking for "special" tabs, like settings and search results. The [SettingsView](https://github.com/atom/settings-view/blob/master/lib/settings-view.coffee) and [ResultsPaneView](https://github.com/atom/find-and-replace/blob/master/lib/project/results-pane.coffee) would then just be extended with a `getIcon` method which returns the name of the octicon to be used (e.g. `tools` and `search`).

Thoughts? :doughnut: If this makes sense, I'd look into adding some tests. :cactus:  

cc @kevinsawicki @Caged (semi-related to https://github.com/atom/tabs/issues/41)
