### PR TITLE
Move last opened tab to front

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -116,6 +116,11 @@ class TabBarView extends View
       @find(".tab.active").removeClass('active')
       tabView.addClass('active')
 
+      if atom.config.get "tabs.moveLastOpenedTabToFront"
+        index = @children(".tab").index(tabView)
+        item = @pane.itemAtIndex(index)
+        @pane.moveItem item, 0
+
   updateActiveTab: ->
     @setActiveTab(@tabForItem(@pane.activeItem))
 

--- a/lib/tabs.coffee
+++ b/lib/tabs.coffee
@@ -4,6 +4,7 @@ TabBarView = require './tab-bar-view'
 module.exports =
   configDefaults:
     showIcons: true
+    moveLastOpenedTabToFront: false
 
   activate: ->
     @paneSubscription = atom.workspaceView.eachPaneView (paneView) =>


### PR DESCRIPTION
I find this feature quite useful since most of the time I have like 10 tabs open, but I switch between two of them very often. I'm too lazy to move them next to each other so that I could switch between them more easily, so I thought I'd add this as a feature :)
