### PR TITLE
expand active tab to show full file name

### DIFF
--- a/stylesheets/tabs.less
+++ b/stylesheets/tabs.less
@@ -21,6 +21,10 @@
     &.active {
       -webkit-flex: 2;
       min-width: -webkit-fit-content;
+
+      .title {
+        padding-right: 10px;
+      }
     }
 
     .title {


### PR DESCRIPTION
When many tabs are open, all of them read '...' which isn't all that helpful.  This will always ensure the active tab is readable.

Prior to this change, you would not be able to read the label site.scss on the active tab:

![screen shot 2014-05-16 at 1 07 17 pm](https://cloud.githubusercontent.com/assets/25/3001792/b887aa04-dd35-11e3-9ccc-c7dbfa3e5233.png)

/cc @kevinsawicki 
