### PR TITLE
Add last active and modified dates to tabs

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -117,7 +117,9 @@ class TabBarView extends View
       tabView.addClass('active')
 
   updateActiveTab: ->
-    @setActiveTab(@tabForItem(@pane.activeItem))
+    tab = @tabForItem(@pane.activeItem)
+    tab.lastActiveAt = new Date()
+    @setActiveTab(tab)
 
   closeTab: (tab) ->
     tab ?= @children('.right-clicked').view()

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -10,7 +10,9 @@ class TabView extends View
       @div class: 'close-icon'
 
   initialize: (@item, @pane) ->
+    @lastActiveAt   = new Date()
     @lastModifiedAt = null
+
     @item.on? 'title-changed', =>
       @updateDataAttributes()
       @updateTitle()


### PR DESCRIPTION
These changes lay the foundation for future work built around tabs.  By having an active and modified date, you can do a few things:
- Sort the `cmd-t` palette by  date.  In Sublime I used this to jump back and forth between two files I'm working on, but Atom sorts this list alphabetically so that dynamic is lost. 
- Automatically close tabs after a certain time of inactivity.  Sometimes I don't do the mundane work of cleaning up previously opened tabs.  If I haven't touched a tab in a few hours, Atom could automatically close it.
- Style tabs based on their age.  Think something like the heat map on [GitHub's blame view](https://github.com/atom/atom/blame/master/README.md). 

/cc @kevinsawicki 
