### PR TITLE
Add feature to change tabs with mouse wheel.

### DIFF
--- a/lib/tabs.coffee
+++ b/lib/tabs.coffee
@@ -4,7 +4,8 @@ TabBarView = require './tab-bar-view'
 module.exports =
   configDefaults:
     showIcons: true
-    changeTabsWithMouseWheel: if process.platform == 'linux' then true else false
+    tabScrolling: if process.platform == 'linux' then true else false
+    tabScrollingDelay: 75
 
   activate: ->
     @paneSubscription = atom.workspaceView.eachPaneView (paneView) =>

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -575,44 +575,37 @@ describe "TabBarView", ->
 
   describe "when the mouse wheel is used on the tab bar", ->
     buildWheelEvent = (direction) ->
-      wheelEvent = $.Event("wheel", {originalEvent: {wheelDelta: direction}})
+      $.Event "wheel", {originalEvent: {wheelDelta: direction}}
 
-    describe "when changeTabsWithMouseWheel is true in package settings", ->
+    describe "when tabScrolling is true in package settings", ->
       beforeEach ->
-        atom.config.set("tabs.changeTabsWithMouseWheel", true)
+        atom.config.set("tabs.tabScrollingDelay", 50)
+        atom.config.set("tabs.tabScrolling", true)
 
-      describe "when the mouse wheel scrolls up one unit", ->
+      describe "when the mouse wheel scrolls up", ->
         it "changes the active tab to the previous tab", ->
           expect(pane.activeItem).toBe item2
-
           tabBar.trigger(buildWheelEvent(1))
-
           expect(pane.activeItem).toBe editor1
 
-      describe "when the mouse wheel scrolls down one unit", ->
+      describe "when the mouse wheel scrolls down", ->
         it "changes the active tab to the previous tab", ->
           expect(pane.activeItem).toBe item2
-
           tabBar.trigger(buildWheelEvent(-1))
-
           expect(pane.activeItem).toBe item1
 
-    describe "when changeTabsWithMouseWheel is false in package settings", ->
+    describe "when tabScrolling is false in package settings", ->
       beforeEach ->
-        atom.config.set("tabs.changeTabsWithMouseWheel", false)
+        atom.config.set("tabs.tabScrolling", false)
 
       describe "when the mouse wheel scrolls up one unit", ->
         it "does not change the active tab", ->
           expect(pane.activeItem).toBe item2
-
           tabBar.trigger(buildWheelEvent(1))
-
           expect(pane.activeItem).toBe item2
 
       describe "when the mouse wheel scrolls down one unit", ->
         it "does not change the active tab", ->
           expect(pane.activeItem).toBe item2
-
           tabBar.trigger(buildWheelEvent(-1))
-
           expect(pane.activeItem).toBe item2


### PR DESCRIPTION
This is a feature of most Linux distros where the mouse wheel will scroll through the open tabs. I made it a configuration option that is only enabled on Linux platforms by default. This will fix #54.
