### PR TITLE
Tab scrolling with mousewheel

### DIFF
--- a/lib/tabs.coffee
+++ b/lib/tabs.coffee
@@ -5,7 +5,7 @@ module.exports =
   configDefaults:
     showIcons: true
     tabScrolling: if process.platform == 'linux' then true else false
-    tabScrollingDelay: 75
+    tabScrollingThreshold: 120
 
   activate: ->
     @paneSubscription = atom.workspaceView.eachPaneView (paneView) =>

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -574,24 +574,33 @@ describe "TabBarView", ->
       expect(newFileHandler.callCount).toBe 1
 
   describe "when the mouse wheel is used on the tab bar", ->
-    buildWheelEvent = (direction) ->
-      $.Event "wheel", {originalEvent: {wheelDelta: direction}}
+    buildWheelEvent = (delta) ->
+      $.Event "wheel", {originalEvent: {wheelDelta: delta}}
 
     describe "when tabScrolling is true in package settings", ->
       beforeEach ->
-        atom.config.set("tabs.tabScrollingDelay", 50)
         atom.config.set("tabs.tabScrolling", true)
+        atom.config.set("tabs.tabScrollingThreshold", 120)
 
       describe "when the mouse wheel scrolls up", ->
         it "changes the active tab to the previous tab", ->
           expect(pane.activeItem).toBe item2
-          tabBar.trigger(buildWheelEvent(1))
+          tabBar.trigger(buildWheelEvent(120))
+          expect(pane.activeItem).toBe editor1
+
+        it "changes the active tab to the previous tab only after the wheelDelta crosses the threshold", ->
+          expect(pane.activeItem).toBe item2
+          tabBar.trigger(buildWheelEvent(50))
+          expect(pane.activeItem).toBe item2
+          tabBar.trigger(buildWheelEvent(50))
+          expect(pane.activeItem).toBe item2
+          tabBar.trigger(buildWheelEvent(50))
           expect(pane.activeItem).toBe editor1
 
       describe "when the mouse wheel scrolls down", ->
         it "changes the active tab to the previous tab", ->
           expect(pane.activeItem).toBe item2
-          tabBar.trigger(buildWheelEvent(-1))
+          tabBar.trigger(buildWheelEvent(-120))
           expect(pane.activeItem).toBe item1
 
     describe "when tabScrolling is false in package settings", ->
@@ -601,11 +610,11 @@ describe "TabBarView", ->
       describe "when the mouse wheel scrolls up one unit", ->
         it "does not change the active tab", ->
           expect(pane.activeItem).toBe item2
-          tabBar.trigger(buildWheelEvent(1))
+          tabBar.trigger(buildWheelEvent(120))
           expect(pane.activeItem).toBe item2
 
       describe "when the mouse wheel scrolls down one unit", ->
         it "does not change the active tab", ->
           expect(pane.activeItem).toBe item2
-          tabBar.trigger(buildWheelEvent(-1))
+          tabBar.trigger(buildWheelEvent(-120))
           expect(pane.activeItem).toBe item2


### PR DESCRIPTION
This uses the `wheelDelta` values to scroll. The default threshold is 120 as that's what a wheel mouse I have generates per notch of the mousewheel. This fells ok on the magic mouse and the trackpad as well.

@mmims try it out on your mouse. It may need to be something like 100.

Closes #63 ; Closes #54 
