### PR TITLE
Removed unused data from the drag event.

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -171,6 +171,8 @@ class TabBarView extends View
 
     item = @pane.getItems()[element.index()]
     if item.getPath?
+      if process.platform isnt 'linux'
+        event.originalEvent.dataTransfer.setData 'text/uri-list', 'file://' + item.getPath()
       event.originalEvent.dataTransfer.setData 'text/plain', item.getPath() ? ''
 
       if item.isModified?() and item.getText?


### PR DESCRIPTION
This extra data had a side effect, on Linux installations of preventing
some data from being transferred to the drop location if the drag
and drop processes are different.

This is surely a work around for some other deeper problem when communicating between two processes in Linux, but as far as I can tell, the text/url-list data is not used, and eliminating it just happens to fix the problem I'm seeing.  I reported the original problem in atom/atom #3033.
