### PR TITLE
Fix drag tab passing URI's

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -172,7 +172,10 @@ class TabBarView extends View
 
     item = @pane.getItems()[element.index()]
     if item.getUri?
-      event.originalEvent.dataTransfer.setData 'text/uri-list', item.getUri?() ? ''
+      if process.platform isnt 'linux' # see #69
+        event.originalEvent.dataTransfer.setData 'text/uri-list', item.getUri?() ? ''
+      else
+        event.originalEvent.dataTransfer.setData 'text/plain', item.getUri?() ? ''
 
       if item.isModified?() and item.getText?
         event.originalEvent.dataTransfer.setData 'has-unsaved-changes', 'true'
@@ -244,7 +247,10 @@ class TabBarView extends View
       {item} = fromPane.find(".tab-bar .sortable:eq(#{fromIndex})").view() ? {}
       @moveItemBetweenPanes(fromPane, fromIndex, toPane, toIndex, item) if item?
     else
-      droppedUri = dataTransfer.getData('text/uri-list')
+      if process.platform isnt 'linux' # see #69
+        droppedUri = dataTransfer.getData('text/uri-list')
+      else
+        droppedUri = dataTransfer.getData('text/plain')
       atom.workspace.open(droppedUri).then (item) =>
         # Move the item from the pane it was opened on to the target pane
         # where it was dropped onto

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -500,7 +500,10 @@ describe "TabBarView", ->
         [dragStartEvent, dropEvent] = buildDragEvents(tabBar.tabAtIndex(1), tabBar.tabAtIndex(1))
         tabBar.onDragStart(dragStartEvent)
 
-        expect(dragStartEvent.originalEvent.dataTransfer.getData("text/uri-list")).toEqual editor1.getUri()
+        if process.platform isnt 'linux' # data is not set on linux, see #69
+        	expect(dragStartEvent.originalEvent.dataTransfer.getData("text/uri-list")).toEqual editor1.getUri()
+        else
+        	expect(dragStartEvent.originalEvent.dataTransfer.getData("text/plain")).toEqual editor1.getUri()
 
     describe "when a tab is dragged to another Atom window", ->
       it "closes the tab in the first window and opens the tab in the second window", ->


### PR DESCRIPTION
Fixes #71.

A couple of things here:

Turns out that removing the hyphen in the event data 'text/url-list' makes the data pass through the event on Linux.  So I renamed the key.

After that, I removed the duplicate data being passed through the drag event.  'text/plain' and 'text/urilist' have the same data for regular file, and 'text/plain' is meaningless for panes that are not files, like 'atom://config'.  So the URI should be sufficient in all(?) cases.

I updated the spec to reflect the changes I made.
