### PR TITLE
Don't stop event propagation from onDrop

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -246,7 +246,6 @@ class TabBarView extends View
 
   onDrop: (event) =>
     event.preventDefault()
-    event.stopPropagation()
     {dataTransfer} = event.originalEvent
 
     return unless dataTransfer.getData('atom-event') is 'true'


### PR DESCRIPTION
Fix for Issue #88 

Allows the 'drop' event to propagate from the tab-bar's `onDrop` handler, so that other packages can listen for it on the pane, workspace, etc.

For example:

``` coffeescript
@paneView.on "drop", ".tab-bar", @_onDropHandler
```
