### PR TITLE
Renaming single tab setting in response to feedback

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -6,9 +6,10 @@ module.exports =
     showIcons:
       type: 'boolean'
       default: true
-    hideTabBarWhenOnlyOneTabIsOpen:
+    alwaysShowTabBar:
       type: 'boolean'
-      default: false
+      default: true
+      description: "Shows the Tab Bar when only 1 tab is open"
     tabScrolling:
       type: 'boolean'
       default: process.platform is 'linux'

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -51,7 +51,7 @@ class TabBarView extends View
 
     @subscriptions.add atom.config.observe 'tabs.tabScrolling', => @updateTabScrolling()
     @subscriptions.add atom.config.observe 'tabs.tabScrollingThreshold', => @updateTabScrollingThreshold()
-    @subscriptions.add atom.config.observe 'tabs.hideTabBarWhenOnlyOneTabIsOpen', => @updateTabBarVisibility()
+    @subscriptions.add atom.config.observe 'tabs.alwaysShowTabBar', => @updateTabBarVisibility()
 
     @updateActiveTab()
 
@@ -113,7 +113,7 @@ class TabBarView extends View
     @updateTabBarVisibility()
 
   updateTabBarVisibility: ->
-    if atom.config.get('tabs.hideTabBarWhenOnlyOneTabIsOpen') and not @shouldAllowDrag()
+    if !atom.config.get('tabs.alwaysShowTabBar') and not @shouldAllowDrag()
       @element.classList.add('hidden')
     else
       @element.classList.remove('hidden')

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -675,9 +675,9 @@ describe "TabBarView", ->
           tabBar.trigger(buildWheelEvent(-120))
           expect(pane.getActiveItem()).toBe item2
 
-  describe "when hideTabBarWhenOnlyOneTabIsOpen is false in package settings", ->
+  describe "when alwaysShowTabBar is true in package settings", ->
     beforeEach ->
-      atom.config.set("tabs.hideTabBarWhenOnlyOneTabIsOpen", false)
+      atom.config.set("tabs.alwaysShowTabBar", true)
 
     describe "when 2 tabs are open", ->
       it "shows the tab bar", ->
@@ -692,9 +692,9 @@ describe "TabBarView", ->
         expect(pane.getItems().length).toBe 1
         expect(tabBar.element).not.toHaveClass 'hidden'
 
-  describe "when hideTabBarWhenOnlyOneTabIsOpen is true in package settings", ->
+  describe "when alwaysShowTabBar is false in package settings", ->
     beforeEach ->
-      atom.config.set("tabs.hideTabBarWhenOnlyOneTabIsOpen", true)
+      atom.config.set("tabs.alwaysShowTabBar", false)
 
     describe "when 2 tabs are open", ->
       it "shows the tab bar", ->


### PR DESCRIPTION
“Hide Tab Bar When Only One Tab Is Open” (default to false) is now
called “Always Show Tab Bar” (default to true) describing the inverse
behavior