### PR TITLE
Add "data-type" attribute to tabs

### DIFF
--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -5,8 +5,6 @@ module.exports =
 class TabView extends HTMLElement
   initialize: (@item) ->
     @classList.add('tab', 'sortable')
-    if itemPath = @item.getPath?()
-      @classList.add('has-path')
 
     @itemTitle = document.createElement('div')
     @itemTitle.classList.add('title')
@@ -110,6 +108,14 @@ class TabView extends HTMLElement
     if itemPath = @item.getPath?()
       @itemTitle.dataset.name = path.basename(itemPath)
       @itemTitle.dataset.path = itemPath
+    else
+      delete @itemTitle.dataset.name
+      delete @itemTitle.dataset.path
+
+    if itemClass = @item.constructor.name
+      @dataset.type = itemClass
+    else
+      delete @dataset.type
 
   updateTitle: ({updateSiblings, useLongTitle}={}) ->
     return if @updatingTitle

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -112,7 +112,7 @@ class TabView extends HTMLElement
       delete @itemTitle.dataset.name
       delete @itemTitle.dataset.path
 
-    if itemClass = @item.constructor.name
+    if itemClass = @item.constructor?.name
       @dataset.type = itemClass
     else
       delete @dataset.type

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -5,6 +5,8 @@ module.exports =
 class TabView extends HTMLElement
   initialize: (@item) ->
     @classList.add('tab', 'sortable')
+    if itemPath = @item.getPath?()
+      @classList.add('has-path')
 
     @itemTitle = document.createElement('div')
     @itemTitle.classList.add('title')

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -95,14 +95,17 @@ describe "TabBarView", ->
       expect(tabBar.find('.tab:eq(0) .title').text()).toBe item1.getTitle()
       expect(tabBar.find('.tab:eq(0) .title')).not.toHaveAttr('data-name')
       expect(tabBar.find('.tab:eq(0) .title')).not.toHaveAttr('data-path')
+      expect(tabBar.find('.tab:eq(0)')).toHaveAttr('data-type', 'TestView')
 
       expect(tabBar.find('.tab:eq(1) .title').text()).toBe editor1.getTitle()
       expect(tabBar.find('.tab:eq(1) .title')).toHaveAttr('data-name', path.basename(editor1.getPath()))
       expect(tabBar.find('.tab:eq(1) .title')).toHaveAttr('data-path', editor1.getPath())
+      expect(tabBar.find('.tab:eq(1)')).toHaveAttr('data-type', 'TextEditor')
 
       expect(tabBar.find('.tab:eq(2) .title').text()).toBe item2.getTitle()
       expect(tabBar.find('.tab:eq(2) .title')).not.toHaveAttr('data-name')
       expect(tabBar.find('.tab:eq(2) .title')).not.toHaveAttr('data-path')
+      expect(tabBar.find('.tab:eq(2)')).toHaveAttr('data-type', 'TestView')
 
     it "highlights the tab for the active pane item", ->
       expect(tabBar.find('.tab:eq(2)')).toHaveClass 'active'


### PR DESCRIPTION
This PR adds a `has-path` class for tabs with a path. This will allow themes to style `<atom-text-editor>` tabs differently than tabs like the Settings or Deprecation Cop etc.

A use case would be to make active tabs have the same (seamless) color as a Syntax theme's background, but tabs like for the Settings, keep the UI colors. See https://github.com/atom/one-dark-ui/pull/11#issuecomment-73009941

![screen shot 2015-02-05 at 4 51 31 pm](https://cloud.githubusercontent.com/assets/378023/6073740/0c3e8b0e-adf6-11e4-973f-9e4ab1d2d3a3.png)

ps. Not sure if there is a better way to tell if it's a `<atom-text-editor>` tab, but using `if itemPath = @item.getPath?()` seems to work.