### PR TITLE
Feature/shift click close tab

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -75,8 +75,11 @@ class TabBarView extends View
       @pane.destroyItem(tab.item)
       false
 
-    @on 'click', '.tab', ({target, which}) =>
+    @on 'click', '.tab', ({target, which, shiftKey}) =>
       tab = $(target).closest('.tab')[0]
+      if which is 1 and shiftKey
+        @pane.destroyItem(tab.item)
+        return false
       if which is 1 and not target.classList.contains('close-icon')
         @pane.activateItem(tab.item)
         @pane.activate()

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -178,6 +178,17 @@ describe "TabBarView", ->
       expect(tabBar.getTabs().length).toBe 2
       expect(tabBar.find('.tab:contains(sample.js)')).not.toExist()
 
+    it "closes the tab when shift clicked", ->
+      event = $.Event 'click'
+      event.which = 1
+      event.shiftKey = true
+      $(tabBar.tabForItem(editor1)).trigger(event)
+      expect(pane.getItems().length).toBe 2
+      expect(pane.getItems().indexOf(editor1)).toBe -1
+      expect(editor1.destroyed).toBeTruthy()
+      expect(tabBar.getTabs().length).toBe 2
+      expect(tabBar.find('.tab:contains(sample.js)')).not.toExist()
+
   describe "when a tab's close icon is clicked", ->
     it "destroys the tab's item on the pane", ->
       $(tabBar.tabForItem(editor1)).find('.close-icon').click()


### PR DESCRIPTION
I find very confortable that my current editor (phpstorm) allows to close tabs using shift + click.

I've implemented this because:
* I don't have a middle button
* I find it faster than clicking on the close button.
* As my first exercise to hack atom :)