### PR TITLE
Added tab-related activationCommands

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -14,12 +14,14 @@ class TabBarView extends View
   initialize: (@pane) ->
     @subscriptions = new CompositeDisposable
 
-    @subscriptions.add atom.commands.add @element,
+    @subscriptions.add atom.commands.add 'atom-workspace',
       'tabs:close-tab': => @closeTab()
       'tabs:close-other-tabs': => @closeOtherTabs()
       'tabs:close-tabs-to-right': => @closeTabsToRight()
       'tabs:close-saved-tabs': => @closeSavedTabs()
       'tabs:close-all-tabs': => @closeAllTabs()
+
+    @subscriptions.add atom.commands.add @element,
       'tabs:split-up': => @splitTab('splitUp')
       'tabs:split-down': => @splitTab('splitDown')
       'tabs:split-left': => @splitTab('splitLeft')
@@ -137,6 +139,7 @@ class TabBarView extends View
 
   closeTab: (tab) ->
     tab ?= @children('.right-clicked')[0]
+    tab ?= @children('.active')[0]
     @pane.destroyItem(tab.item)
 
   splitTab: (fn) ->
@@ -150,12 +153,14 @@ class TabBarView extends View
   closeOtherTabs: ->
     tabs = @getTabs()
     active = @children('.right-clicked')[0]
+    active ?= @children('.active')[0]
     return unless active?
     @closeTab tab for tab in tabs when tab isnt active
 
   closeTabsToRight: ->
     tabs = @getTabs()
     active = @children('.right-clicked')[0]
+    active ?= @children('.active')[0]
     index = tabs.indexOf(active)
     return if index is -1
     @closeTab tab for tab, i in tabs when i > index


### PR DESCRIPTION
Pulling out tab-related commands to the workspace level so commands like "Close All Tabs" are generally available from the command pane.