### PR TITLE
Shift + Scroll shouldn't switch tabs. Fixes #139

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -299,6 +299,8 @@ class TabBarView extends View
       atom.focus()
 
   onMouseWheel: ({originalEvent}) =>
+    return if originalEvent.shiftKey
+
     @wheelDelta ?= 0
     @wheelDelta += originalEvent.wheelDelta
 

--- a/spec/event-helpers.coffee
+++ b/spec/event-helpers.coffee
@@ -28,3 +28,6 @@ module.exports.buildDragEvents = (dragged, dropTarget) ->
 
 module.exports.buildWheelEvent = (delta) ->
   $.Event "wheel", {originalEvent: {wheelDelta: delta}}
+
+module.exports.buildWheelPlusShiftEvent = (delta) ->
+  $.Event "wheel", {originalEvent: {wheelDelta: delta, shiftKey: true}}

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -3,7 +3,7 @@ _ = require 'underscore-plus'
 path = require 'path'
 TabBarView = require '../lib/tab-bar-view'
 TabView = require '../lib/tab-view'
-{triggerMouseDownEvent, buildDragEvents, buildWheelEvent} = require "./event-helpers"
+{triggerMouseDownEvent, buildDragEvents, buildWheelEvent, buildWheelPlusShiftEvent} = require "./event-helpers"
 
 describe "Tabs package main", ->
   workspaceElement = null
@@ -659,6 +659,18 @@ describe "TabBarView", ->
           expect(pane.getActiveItem()).toBe item2
           tabBar.trigger(buildWheelEvent(-120))
           expect(pane.getActiveItem()).toBe item1
+
+      describe "when the mouse wheel scrolls up and shift key is pressed", ->
+        it "does not change the active tab", ->
+          expect(pane.getActiveItem()).toBe item2
+          tabBar.trigger(buildWheelPlusShiftEvent(120))
+          expect(pane.getActiveItem()).toBe item2
+
+      describe "when the mouse wheel scrolls down and shift key is pressed", ->
+        it "does not change the active tab", ->
+          expect(pane.getActiveItem()).toBe item2
+          tabBar.trigger(buildWheelPlusShiftEvent(-120))
+          expect(pane.getActiveItem()).toBe item2
 
     describe "when tabScrolling is false in package settings", ->
       beforeEach ->


### PR DESCRIPTION
Pressing <kbd>Shift</kbd> + <kbd>Scroll</kbd> shouldn't switch active tab when option "Tab Scrolling" is also active.

This PR will ignore Tab Scrolling when <kbd>Shift</kbd> is pressed, taking horizontal scrolling as primary action.

Fixes https://github.com/atom/tabs/issues/139

Atom 0.200.0
Windows 8.1 64-bits