### PR TITLE
Added temporary tabs

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -13,10 +13,10 @@ module.exports =
     tabScrollingThreshold:
       type: 'integer'
       default: 120
-    temporaryTabs:
+    useTransientBehavior:
       type: 'boolean'
       default: true
-      description: 'Tabs will close when they lose focus, Tabs can be locked by double clicking the title'
+      description: 'Tabs will only stay open if they are modified or double-clicked'
 
   activate: ->
     @tabBarViews = []

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -13,7 +13,7 @@ module.exports =
     tabScrollingThreshold:
       type: 'integer'
       default: 120
-    useTransientBehavior:
+    usePreviewTabs:
       type: 'boolean'
       default: true
       description: 'Tabs will only stay open if they are modified or double-clicked'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -13,6 +13,10 @@ module.exports =
     tabScrollingThreshold:
       type: 'integer'
       default: 120
+    temporaryTabs:
+      type: 'boolean'
+      default: true
+      description: 'Tabs will close when they lose focus, Tabs can be locked by double clicking the title'
 
   activate: ->
     @tabBarViews = []

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -48,7 +48,7 @@ class TabBarView extends View
 
     @subscriptions.add @pane.onDidChangeActiveItem (item) =>
       if atom.config.get('tabs.useTransientBehavior') and item instanceof TextEditor
-        if @tab instanceof TabView and @getTabs().length > 1 and @tab.item isnt item and !@tab.keepOpen and @tab.item instanceof TextEditor
+        if @tab instanceof TabView and @getTabs().length > 1 and @tab.item isnt item and not @tab.keepOpen and @tab.item instanceof TextEditor
           @pane.destroyItem @tab.item
         @tab = @tabForItem(item)
       @updateActiveTab()
@@ -92,7 +92,7 @@ class TabBarView extends View
   addTabForItem: (item, index) ->
     tabView = new TabView()
     tabView.initialize(item)
-    if atom.config.get('tabs.useTransientBehavior') and !@tab and item instanceof TextEditor
+    if atom.config.get('tabs.useTransientBehavior') and not @tab and item instanceof TextEditor
       @tab = tabView
     @insertTabAtIndex(tabView, index)
 

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -46,7 +46,11 @@ class TabBarView extends View
     @subscriptions.add @pane.onDidRemoveItem ({item}) =>
       @removeTabForItem(item)
 
-    @subscriptions.add @pane.onDidChangeActiveItem =>
+    @subscriptions.add @pane.onDidChangeActiveItem (item) =>
+      if atom.config.get('tabs.temporaryTabs')
+        if @tab instanceof TabView && @getTabs().length > 1
+          @pane.destroyItem(@tab.item) if !@tab.open
+        @tab = @tabForItem(item)
       @updateActiveTab()
 
     @subscriptions.add atom.config.observe 'tabs.tabScrolling', => @updateTabScrolling()
@@ -88,6 +92,9 @@ class TabBarView extends View
   addTabForItem: (item, index) ->
     tabView = new TabView()
     tabView.initialize(item)
+    if atom.config.get('tabs.temporaryTabs')
+      if !@tab
+        @tab = tabView
     @insertTabAtIndex(tabView, index)
 
   moveItemTabToIndex: (item, index) ->

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -47,8 +47,8 @@ class TabBarView extends View
       @removeTabForItem(item)
 
     @subscriptions.add @pane.onDidChangeActiveItem (item) =>
-      if atom.config.get('tabs.useTransientBehavior') and item instanceof TextEditor
-        if @tab instanceof TabView and @getTabs().length > 1 and @tab.item isnt item and not @tab.keepOpen and @tab.item instanceof TextEditor
+      if atom.config.get('tabs.usePreviewTabs') and item instanceof TextEditor
+        if @tab instanceof TabView and @getTabs().length > 1 and @tab.item isnt item and @tab.isPreviewTab and @tab.item instanceof TextEditor
           @pane.destroyItem @tab.item
         @tab = @tabForItem(item)
       @updateActiveTab()
@@ -92,7 +92,7 @@ class TabBarView extends View
   addTabForItem: (item, index) ->
     tabView = new TabView()
     tabView.initialize(item)
-    if atom.config.get('tabs.useTransientBehavior') and not @tab and item instanceof TextEditor
+    if atom.config.get('tabs.usePreviewTabs') and not @tab and item instanceof TextEditor
       @tab = tabView
     @insertTabAtIndex(tabView, index)
 

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -48,7 +48,7 @@ class TabBarView extends View
 
     @subscriptions.add @pane.onDidChangeActiveItem (item) =>
       if atom.config.get('tabs.usePreviewTabs') and item instanceof TextEditor
-        if @tab instanceof TabView and @getTabs().length > 1 and @tab.item isnt item and @tab.isPreviewTab and @tab.item instanceof TextEditor
+        if @getTabs().length > 1 and @tab.item isnt item and @tab.isPreviewTab
           @pane.destroyItem @tab.item
         @tab = @tabForItem(item)
       @updateActiveTab()

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -2,7 +2,7 @@ BrowserWindow = null # Defer require until actually used
 RendererIpc = require 'ipc'
 
 {$, View} = require 'atom-space-pen-views'
-{CompositeDisposable} = require 'atom'
+{CompositeDisposable, TextEditor} = require 'atom'
 _ = require 'underscore-plus'
 TabView = require './tab-view'
 
@@ -47,9 +47,9 @@ class TabBarView extends View
       @removeTabForItem(item)
 
     @subscriptions.add @pane.onDidChangeActiveItem (item) =>
-      if atom.config.get('tabs.temporaryTabs')
-        if @tab instanceof TabView && @getTabs().length > 1
-          @pane.destroyItem(@tab.item) if !@tab.open
+      if atom.config.get('tabs.useTransientBehavior') and item instanceof TextEditor
+        if @tab instanceof TabView and @getTabs().length > 1 and @tab.item isnt item and !@tab.keepOpen and @tab.item instanceof TextEditor
+          @pane.destroyItem @tab.item
         @tab = @tabForItem(item)
       @updateActiveTab()
 
@@ -92,9 +92,8 @@ class TabBarView extends View
   addTabForItem: (item, index) ->
     tabView = new TabView()
     tabView.initialize(item)
-    if atom.config.get('tabs.temporaryTabs')
-      if !@tab
-        @tab = tabView
+    if atom.config.get('tabs.useTransientBehavior') and !@tab and item instanceof TextEditor
+      @tab = tabView
     @insertTabAtIndex(tabView, index)
 
   moveItemTabToIndex: (item, index) ->

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -1,20 +1,22 @@
 path = require 'path'
 {$} = require 'atom-space-pen-views'
+{TextEditor} = require 'atom'
 
 module.exports =
 class TabView extends HTMLElement
   initialize: (@item) ->
-    @open = false
-    if atom.config.get('tabs.temporaryTabs')
+    @keepOpen = false
+    if atom.config.get('tabs.useTransientBehavior') and @item instanceof TextEditor
       @addEventListener 'dblclick', =>
-        @open = true
+        @keepOpen = true
         @itemTitle.classList.remove('temp')
+    else
+      @keepOpen = true
 
     @classList.add('tab', 'sortable')
 
     @itemTitle = document.createElement('div')
-    if atom.config.get('tabs.temporaryTabs')
-      @itemTitle.classList.add('temp')
+    @itemTitle.classList.add('temp') unless @keepOpen
     @itemTitle.classList.add('title')
     @appendChild(@itemTitle)
 
@@ -164,8 +166,8 @@ class TabView extends HTMLElement
 
   updateModifiedStatus: ->
     if @item.isModified?()
-      if atom.config.get('tabs.temporaryTabs')
-        @open = true
+      if atom.config.get('tabs.useTransientBehavior')
+        @keepOpen = true
         @itemTitle.classList.remove('temp')
       @classList.add('modified') unless @isModified
       @isModified = true

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -164,6 +164,9 @@ class TabView extends HTMLElement
 
   updateModifiedStatus: ->
     if @item.isModified?()
+      if atom.config.get('tabs.temporaryTabs')
+        @open = true
+        @itemTitle.classList.remove('temp')
       @classList.add('modified') unless @isModified
       @isModified = true
     else

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -4,9 +4,17 @@ path = require 'path'
 module.exports =
 class TabView extends HTMLElement
   initialize: (@item) ->
+    @open = false
+    if atom.config.get('tabs.temporaryTabs')
+      @addEventListener 'dblclick', =>
+        @open = true
+        @itemTitle.classList.remove('temp')
+
     @classList.add('tab', 'sortable')
 
     @itemTitle = document.createElement('div')
+    if atom.config.get('tabs.temporaryTabs')
+      @itemTitle.classList.add('temp')
     @itemTitle.classList.add('title')
     @appendChild(@itemTitle)
 

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -5,18 +5,17 @@ path = require 'path'
 module.exports =
 class TabView extends HTMLElement
   initialize: (@item) ->
-    @keepOpen = false
-    if atom.config.get('tabs.useTransientBehavior') and @item instanceof TextEditor
+    @isPreviewTab = false
+    if atom.config.get('tabs.usePreviewTabs') and @item instanceof TextEditor
+      @isPreviewTab = true
       @addEventListener 'dblclick', =>
-        @keepOpen = true
+        @isPreviewTab = false
         @itemTitle.classList.remove('temp')
-    else
-      @keepOpen = true
 
     @classList.add('tab', 'sortable')
 
     @itemTitle = document.createElement('div')
-    @itemTitle.classList.add('temp') unless @keepOpen
+    @itemTitle.classList.add('temp') if @isPreviewTab
     @itemTitle.classList.add('title')
     @appendChild(@itemTitle)
 
@@ -166,8 +165,8 @@ class TabView extends HTMLElement
 
   updateModifiedStatus: ->
     if @item.isModified?()
-      if atom.config.get('tabs.useTransientBehavior')
-        @keepOpen = true
+      if atom.config.get('tabs.usePreviewTabs')
+        @isPreviewTab = false
         @itemTitle.classList.remove('temp')
       @classList.add('modified') unless @isModified
       @isModified = true

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -709,3 +709,62 @@ describe "TabBarView", ->
         pane.destroyItem(item2)
         expect(pane.getItems().length).toBe 1
         expect(tabBar.element).toHaveClass 'hidden'
+
+  describe "when useTransientBehavior is true in package settings", ->
+    beforeEach ->
+      atom.config.set("tabs.useTransientBehavior", true)
+
+      waitsForPromise ->
+        pane.destroyItems()
+        atom.workspace.open('sample.js').then (o) -> editor1 = o
+
+    describe "when the active pane item changes and there are no editors", ->
+      it "adds tab with class 'temp'", ->
+        pane.activateItem(editor1)
+        expect(tabBar.find('.tab .temp').length).toBe 1
+        expect(tabBar.find('.tab:eq(0) .title')).toHaveClass 'temp'
+
+    describe "when a new item is added to the pane", ->
+      it "removes any tabs with the 'temp' class leaving only one 'temp' tab", ->
+        pane.activateItem(editor1)
+        editor2 = null
+        waitsForPromise ->
+          atom.project.open('sample.txt').then (o) -> editor2 = o
+        runs ->
+          pane.activateItem(editor2)
+          expect(tabBar.find('.tab .temp').length).toBe 1
+          expect(tabBar.find('.tab:eq(0) .title')).toHaveClass 'temp'
+
+      it "removes 'temp' class from the new tab if the item is initially modified", ->
+        editor2 = null
+        waitsForPromise ->
+          atom.project.open('sample.txt').then (o) -> editor2 = o
+        runs ->
+          editor2.insertText('x')
+          pane.activateItem(editor2)
+          expect(tabBar.find('.tab:eq(0) .title')).not.toHaveClass 'temp'
+
+  describe "when useTransientBehavior is false in package settings", ->
+    beforeEach ->
+      atom.config.set("tabs.useTransientBehavior", false)
+
+      waitsForPromise ->
+        pane.destroyItems()
+        atom.workspace.open('sample.js').then (o) -> editor1 = o
+
+    describe "when the active pane item changes and there are no editors", ->
+      it "adds tab without class 'temp'", ->
+        pane.activateItem(editor1)
+        expect(tabBar.find('.tab').length).toBe 1
+        expect(tabBar.find('.tab:eq(0) .title')).not.toHaveClass 'temp'
+
+    describe "when a new item is added to the pane", ->
+      it "adds tab without removing tabs", ->
+        pane.activateItem(editor1)
+        editor2 = null
+        waitsForPromise ->
+          atom.project.open('sample.txt').then (o) -> editor2 = o
+        runs ->
+          pane.activateItem(editor2)
+          expect(tabBar.find('.tab').length).toBe 2
+          expect(tabBar.find('.tab:eq(1) .title')).not.toHaveClass 'temp'

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -780,18 +780,6 @@ describe "TabBarView", ->
         expect(tabBar.tabForItem(editor2)).toExist()
         expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
 
-    describe 'when opening an image', ->
-      it 'should be temporary', ->
-        imageView = null
-
-        waitsForPromise ->
-          atom.workspace.open('sample.png').then (o) ->
-            imageView = o
-            pane.activateItem(imageView)
-
-        runs ->
-          expect($(tabBar.tabForItem(imageView)).find('.title')).toHaveClass 'temp'
-
   describe 'when editing a file', ->
     it 'makes the tab permanent', ->
       editor1 = null

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -780,14 +780,15 @@ describe "TabBarView", ->
         expect(tabBar.tabForItem(editor2)).toExist()
         expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
 
-  describe 'when editing a file', ->
-    it 'makes the tab permanent', ->
-      editor1 = null
-      waitsForPromise ->
-        atom.workspace.open('sample.txt').then (o) ->
-          editor1 = o
-          pane.activateItem(editor1)
-          editor1.insertText('x')
+    describe 'when editing a file', ->
+      it 'makes the tab permanent', ->
+        editor1 = null
+        waitsForPromise ->
+          atom.workspace.open('sample.txt').then (o) ->
+            editor1 = o
+            pane.activateItem(editor1)
+            editor1.insertText('x')
+            advanceClock(editor1.buffer.stoppedChangingDelay)
 
-      runs ->
-        expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'
+        runs ->
+          expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -710,9 +710,9 @@ describe "TabBarView", ->
         expect(pane.getItems().length).toBe 1
         expect(tabBar.element).toHaveClass 'hidden'
 
-  describe "when useTransientBehavior is true in package settings", ->
+  describe "when usePreviewTabs is true in package settings", ->
     beforeEach ->
-      atom.config.set("tabs.useTransientBehavior", true)
+      atom.config.set("tabs.usePreviewTabs", true)
       pane.destroyItems()
 
     describe "when opening a new tab", ->

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -31,6 +31,9 @@
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
+      &.temp {
+        font-style: italic;
+      }
     }
 
     .hide-icon {


### PR DESCRIPTION
Introduces new setting that opens all tabs in a temp state, allowing them to be closed when focus is changed from item to item.

Origin: ddavison/sublime-tabs#43