### PR TITLE
Make commands available in the entire workspace

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -14,7 +14,7 @@ class TabBarView extends View
   initialize: (@pane) ->
     @subscriptions = new CompositeDisposable
 
-    @subscriptions.add atom.commands.add @element,
+    @subscriptions.add atom.commands.add 'atom-workspace',
       'tabs:close-tab': => @closeTab()
       'tabs:close-other-tabs': => @closeOtherTabs()
       'tabs:close-tabs-to-right': => @closeTabsToRight()


### PR DESCRIPTION
Currently, the commands from the `tab` package are only available from the command palette if you open it after clicking on the tab bar.

This PR makes them available in the command palette regardless from where it's opened.
This makes e.g. adding a keybind for 'Close All Tabs' easy.