### PR TITLE
Delay pane activation on mousedown to fix loss of focus

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -63,7 +63,7 @@ class TabBarView extends View
         false
       else if which is 1 and not target.classList.contains('close-icon')
         @pane.activateItem(tab.item)
-        @pane.activate()
+        setImmediate => @pane.activate()
         true
       else if which is 2
         @pane.destroyItem(tab.item)

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -169,7 +169,12 @@ describe "TabBarView", ->
       expect(pane.getActiveItem()).toBe pane.getItems()[2]
       expect(event.preventDefault).not.toHaveBeenCalled() # allows dragging
 
-      expect(pane.activate.callCount).toBe 2
+      # Pane activation is delayed because focus is stolen by the tab bar
+      # immediately afterward unless propagation of the mousedown event is
+      # stopped. But stopping propagation of the mousedown event prevents the
+      # dragstart event from occurring.
+      waits(1)
+      runs -> expect(pane.activate.callCount).toBe 2
 
     it "closes the tab when middle clicked", ->
       event = triggerMouseDownEvent(tabBar.tabForItem(editor1), which: 2)


### PR DESCRIPTION
Force pushed an update to this pull request. This should now fix atom/atom#6662 without breaking dragging.

There's a complex interaction going on between `focus`, `mousedown`, and `dragstart` events. It seems that no matter what I try, if `document.activeElement` changes synchronously during a `mousedown` event, the subsequent `dragstart` event is never handled. There may be a hidden issue regarding our focus handling in core that would enable a more elegant fix to this, but I haven't been able to find it and would like to just fix the immediate issue for now.
