### PR TITLE
Preview tab tweaks

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -15,7 +15,7 @@ module.exports =
       default: 120
     usePreviewTabs:
       type: 'boolean'
-      default: true
+      default: false
       description: 'Tabs will only stay open if they are modified or double-clicked'
 
   activate: ->

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -90,9 +90,6 @@ class TabBarView extends View
     RendererIpc.removeListener('tab:dropped', @onDropOnOtherWindow)
     @subscriptions.dispose()
 
-  isPreviewableItem: (item) ->
-    atom.config.get('tabs.usePreviewTabs') and item instanceof TextEditor
-
   setInitialPreviewTab: ->
     activeItem = @pane.getActiveItem()
     for tab in @getTabs() when tab.isPreviewTab

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -48,7 +48,7 @@ class TabBarView extends View
 
     @subscriptions.add @pane.onDidChangeActiveItem (item) =>
       if atom.config.get('tabs.usePreviewTabs') and item instanceof TextEditor
-        if @getTabs().length > 1 and @tab.item isnt item and @tab.isPreviewTab
+        if @getTabs().length > 1 and @tab?.item isnt item and @tab?.isPreviewTab
           @pane.destroyItem(@tab.item)
         @tab = @tabForItem(item)
       @updateActiveTab()

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -36,7 +36,7 @@ class TabBarView extends View
 
     @paneContainer = @pane.getContainer()
     @addTabForItem(item) for item in @pane.getItems()
-    @clearPreviewTabs()
+    @setInitialPreviewTab()
 
     @subscriptions.add @pane.onDidDestroy =>
       @unsubscribe()
@@ -92,6 +92,12 @@ class TabBarView extends View
 
   isPreviewableItem: (item) ->
     atom.config.get('tabs.usePreviewTabs') and item instanceof TextEditor
+
+  setInitialPreviewTab: ->
+    activeItem = @pane.getActiveItem()
+    for tab in @getTabs() when tab.isPreviewTab
+      tab.clearPreview() if tab.item isnt activeItem
+    return
 
   clearPreviewTabs: ->
     tab.clearPreview() for tab in @getTabs()

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -49,7 +49,7 @@ class TabBarView extends View
     @subscriptions.add @pane.onDidChangeActiveItem (item) =>
       if atom.config.get('tabs.usePreviewTabs') and item instanceof TextEditor
         if @getTabs().length > 1 and @tab.item isnt item and @tab.isPreviewTab
-          @pane.destroyItem @tab.item
+          @pane.destroyItem(@tab.item)
         @tab = @tabForItem(item)
       @updateActiveTab()
 

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -50,7 +50,7 @@ class TabBarView extends View
       @removeTabForItem(item)
 
     @subscriptions.add @pane.onDidChangeActiveItem (item) =>
-      if atom.config.get('tabs.usePreviewTabs') and item instanceof TextEditor
+      if @isPreviewableItem(item)
         if @getTabs().length > 1 and @tab?.item isnt item and @tab?.isPreviewTab
           @pane.destroyItem(@tab.item)
         @tab = @tabForItem(item)
@@ -92,11 +92,14 @@ class TabBarView extends View
     RendererIpc.removeListener('tab:dropped', @onDropOnOtherWindow)
     @subscriptions.dispose()
 
+  isPreviewableItem: (item) ->
+    atom.config.get('tabs.usePreviewTabs') and item instanceof TextEditor
+
   addTabForItem: (item, index) ->
     tabView = new TabView()
     tabView.initialize(item)
-    if atom.config.get('tabs.usePreviewTabs') and not @tab and item instanceof TextEditor
-      @tab = tabView
+    @tab ?= tabView if @isPreviewableItem(item)
+
     @insertTabAtIndex(tabView, index)
 
   moveItemTabToIndex: (item, index) ->

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -51,9 +51,7 @@ class TabBarView extends View
       @removeTabForItem(item)
 
     @subscriptions.add @pane.onDidChangeActiveItem (item) =>
-      if @isPreviewableItem(item) and @getTabs().length > 1
-        @pane.destroyItem(@previewTab.item) if @previewTab?.isPreviewTab
-        @previewTab = @tabForItem(item)
+      @destroyPreviousPreviewTab(item)
       @updateActiveTab()
 
     @subscriptions.add atom.config.observe 'tabs.tabScrolling', => @updateTabScrolling()
@@ -99,10 +97,20 @@ class TabBarView extends View
     tab.clearPreview() for tab in @getTabs()
     return
 
+  storePreviewTabToDestroy: ->
+    for tab in @getTabs() when tab.isPreviewTab
+      @previewTabToDestroy = tab
+    return
+
+  destroyPreviousPreviewTab: ->
+    if @previewTabToDestroy?.isPreviewTab
+      @pane.destroyItem(@previewTabToDestroy.item)
+    @previewTabToDestroy = null
+
   addTabForItem: (item, index) ->
     tabView = new TabView()
     tabView.initialize(item)
-    @previewTab ?= tabView if tabView.isPreviewTab
+    @storePreviewTabToDestroy() if tabView.isPreviewTab
     @insertTabAtIndex(tabView, index)
 
   moveItemTabToIndex: (item, index) ->

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -14,6 +14,9 @@ class TabBarView extends View
   initialize: (@pane) ->
     @subscriptions = new CompositeDisposable
 
+    @subscriptions.add atom.commands.add atom.views.getView(@pane),
+      'tabs:keep-preview-tab': => tab.clearPreview() for tab in @getTabs()
+
     @subscriptions.add atom.commands.add @element,
       'tabs:close-tab': => @closeTab()
       'tabs:close-other-tabs': => @closeOtherTabs()

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -50,10 +50,9 @@ class TabBarView extends View
       @removeTabForItem(item)
 
     @subscriptions.add @pane.onDidChangeActiveItem (item) =>
-      if @isPreviewableItem(item)
-        if @getTabs().length > 1 and @tab?.item isnt item and @tab?.isPreviewTab
-          @pane.destroyItem(@tab.item)
-        @tab = @tabForItem(item)
+      if @isPreviewableItem(item) and @getTabs().length > 1
+        previewTab = @getPreviewTab()
+        @pane.destroyItem(previewTab.item) if previewTab
       @updateActiveTab()
 
     @subscriptions.add atom.config.observe 'tabs.tabScrolling', => @updateTabScrolling()
@@ -98,9 +97,10 @@ class TabBarView extends View
   addTabForItem: (item, index) ->
     tabView = new TabView()
     tabView.initialize(item)
-    @tab ?= tabView if @isPreviewableItem(item)
-
     @insertTabAtIndex(tabView, index)
+
+  getPreviewTab: ->
+    _.detect @getTabs(), (tab) -> tab.isPreviewTab
 
   moveItemTabToIndex: (item, index) ->
     if tab = @tabForItem(item)

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -51,7 +51,7 @@ class TabBarView extends View
       @removeTabForItem(item)
 
     @subscriptions.add @pane.onDidChangeActiveItem (item) =>
-      @destroyPreviousPreviewTab(item)
+      @destroyPreviousPreviewTab()
       @updateActiveTab()
 
     @subscriptions.add atom.config.observe 'tabs.tabScrolling', => @updateTabScrolling()

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -7,9 +7,6 @@ class TabView extends HTMLElement
   initialize: (@item) ->
     @isPreviewTab = atom.config.get('tabs.usePreviewTabs') and @item instanceof TextEditor
 
-    if @isPreviewTab
-      @addEventListener 'dblclick', => @clearPreview()
-
     @classList.add('tab', 'sortable')
 
     @itemTitle = document.createElement('div')
@@ -30,6 +27,7 @@ class TabView extends HTMLElement
     if @isPreviewTab
       @itemTitle.classList.add('temp')
       @classList.add('preview-tab')
+      @addEventListener 'dblclick', => @clearPreview()
 
   handleEvents: ->
     titleChangedHandler = =>

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -5,9 +5,9 @@ path = require 'path'
 module.exports =
 class TabView extends HTMLElement
   initialize: (@item) ->
-    @isPreviewTab = false
-    if atom.config.get('tabs.usePreviewTabs') and @item instanceof TextEditor
-      @isPreviewTab = true
+    @isPreviewTab = atom.config.get('tabs.usePreviewTabs') and @item instanceof TextEditor
+
+    if @isPreviewTab
       @addEventListener 'dblclick', => @clearPreview()
 
     @classList.add('tab', 'sortable')

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -13,7 +13,6 @@ class TabView extends HTMLElement
     @classList.add('tab', 'sortable')
 
     @itemTitle = document.createElement('div')
-    @itemTitle.classList.add('temp') if @isPreviewTab
     @itemTitle.classList.add('title')
     @appendChild(@itemTitle)
 
@@ -27,6 +26,10 @@ class TabView extends HTMLElement
     @updateIcon()
     @updateModifiedStatus()
     @setupTooltip()
+
+    if @isPreviewTab
+      @itemTitle.classList.add('temp')
+      @classList.add('preview-tab')
 
   handleEvents: ->
     titleChangedHandler = =>
@@ -158,6 +161,7 @@ class TabView extends HTMLElement
   clearPreview: ->
     @isPreviewTab = false
     @itemTitle.classList.remove('temp')
+    @classList.remove('preview-tab')
 
   updateIconVisibility: ->
     if atom.config.get 'tabs.showIcons'

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -8,9 +8,7 @@ class TabView extends HTMLElement
     @isPreviewTab = false
     if atom.config.get('tabs.usePreviewTabs') and @item instanceof TextEditor
       @isPreviewTab = true
-      @addEventListener 'dblclick', =>
-        @isPreviewTab = false
-        @itemTitle.classList.remove('temp')
+      @addEventListener 'dblclick', => @clearPreview()
 
     @classList.add('tab', 'sortable')
 
@@ -157,6 +155,10 @@ class TabView extends HTMLElement
   getTabs: ->
     @parentElement?.querySelectorAll('.tab') ? []
 
+  clearPreview: ->
+    @isPreviewTab = false
+    @itemTitle.classList.remove('temp')
+
   updateIconVisibility: ->
     if atom.config.get 'tabs.showIcons'
       @itemTitle.classList.remove('hide-icon')
@@ -165,9 +167,7 @@ class TabView extends HTMLElement
 
   updateModifiedStatus: ->
     if @item.isModified?()
-      if atom.config.get('tabs.usePreviewTabs')
-        @isPreviewTab = false
-        @itemTitle.classList.remove('temp')
+      @clearPreview() if atom.config.get('tabs.usePreviewTabs')
       @classList.add('modified') unless @isModified
       @isModified = true
     else

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -169,7 +169,7 @@ class TabView extends HTMLElement
 
   updateModifiedStatus: ->
     if @item.isModified?()
-      @clearPreview() if atom.config.get('tabs.usePreviewTabs')
+      @clearPreview()
       @classList.add('modified') unless @isModified
       @isModified = true
     else

--- a/menus/tabs.cson
+++ b/menus/tabs.cson
@@ -13,7 +13,9 @@
     {label: 'Split Left', command: 'tabs:split-left'}
     {label: 'Split Right', command: 'tabs:split-right'}
   ]
-
+  '.tab.preview-tab': [
+    {label: 'Keep Preview Tab', command: 'tabs:keep-preview-tab'}
+  ]
   '.tab-bar': [
     {label: 'Reopen Closed Tab', command: 'pane:reopen-closed-item'}
   ]

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -843,3 +843,16 @@ describe "TabBarView", ->
           expect(pane.getItems().length).toBe 2
           expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'
           expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
+
+    describe "when splitting a preview tab", ->
+      it "makes the tab a preview tab in the new pane", ->
+        editor1 = null
+        waitsForPromise ->
+          atom.project.open('sample.txt').then (o) -> editor1 = o
+
+        runs ->
+          pane.activateItem(editor1)
+          pane2 = pane.splitRight(copyActiveItem: true)
+          tabBar2 = new TabBarView(pane2)
+
+          expect($(tabBar2.tabForItem(pane2.getActiveItem())).find('.title')).toHaveClass 'temp'

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -769,7 +769,7 @@ describe "TabBarView", ->
           expect(tabBar.tabForItem(editor1)).not.toExist()
           expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
 
-      it 'makes the tab permanent when dbl clicking the tab', ->
+      it 'makes the tab permanent when double clicking the tab', ->
         editor2 = null
 
         waitsForPromise ->
@@ -818,3 +818,28 @@ describe "TabBarView", ->
 
         runs ->
           expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'
+
+    describe 'when switching from a preview tab to a permanent tab', ->
+      it "keeps the preview tab open", ->
+        atom.config.set("tabs.usePreviewTabs", false)
+        editor1 = null
+        editor2 = null
+
+        waitsForPromise ->
+          atom.workspace.open('sample.txt').then (o) ->
+            editor1 = o
+            pane.activateItem(editor1)
+
+        runs ->
+          atom.config.set("tabs.usePreviewTabs", true)
+
+        waitsForPromise ->
+          atom.workspace.open('sample2.txt').then (o) ->
+            editor2 = o
+            pane.activateItem(editor2)
+
+        runs ->
+          pane.activateItem(editor1)
+          expect(pane.getItems().length).toBe 2
+          expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'
+          expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -732,6 +732,7 @@ describe "TabBarView", ->
         editor1 = null
         waitsForPromise ->
           atom.project.open('sample.txt').then (o) -> editor1 = o
+
         runs ->
           pane.activateItem(editor1)
           expect(tabBar.find('.tab .temp').length).toBe 1
@@ -755,6 +756,7 @@ describe "TabBarView", ->
           expect(editor2.isDestroyed()).toBe false
           expect(tabBar.tabForItem(editor1)).not.toExist()
           expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
+
       it 'makes the tab permanent when dbl clicking the tab', ->
         editor2 = null
 

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -738,6 +738,18 @@ describe "TabBarView", ->
           expect(tabBar.find('.tab .temp').length).toBe 1
           expect(tabBar.find('.tab:eq(0) .title')).toHaveClass 'temp'
 
+    describe "when tabs:keep-preview-tab is trigger on the pane", ->
+      it "removes the 'temp' class", ->
+        editor1 = null
+        waitsForPromise ->
+          atom.project.open('sample.txt').then (o) -> editor1 = o
+
+        runs ->
+          pane.activateItem(editor1)
+          expect(tabBar.find('.tab .temp').length).toBe 1
+          atom.commands.dispatch(atom.views.getView(atom.workspace.getActivePane()), 'tabs:keep-preview-tab')
+          expect(tabBar.find('.tab .temp').length).toBe 0
+
     describe "when there is a temp tab already", ->
       it "it will replace an existing temporary tab", ->
         editor1 = null


### PR DESCRIPTION
Follow on to #145 

- [x] Disable preview tabs by default to now, will revisit in the future once it has been shipped for longer.
- [x] Minor formatting tweaks
- [x] Add command/context menu to keep a preview tab `tabs:keep-preview-tab`
- [x] Fix issues with clearing preview tabs across editor restarts