### PR TITLE
Serialize preview tab uri

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -39,6 +39,7 @@ module.exports =
   deactivate: ->
     @paneSubscription.dispose()
     tabBarView.remove() for tabBarView in @tabBarViews
+    return
 
   serialize: ->
     for tabBarView in @tabBarViews

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -18,13 +18,15 @@ module.exports =
       default: false
       description: 'Tabs will only stay open if they are modified or double-clicked'
 
-  activate: ->
+  activate: (state) ->
+    state = [] unless Array.isArray(state)
     @tabBarViews = []
 
     TabBarView = require './tab-bar-view'
     _ = require 'underscore-plus'
+
     @paneSubscription = atom.workspace.observePanes (pane) =>
-      tabBarView = new TabBarView(pane)
+      tabBarView = new TabBarView(pane, state.pop())
 
       paneElement = atom.views.getView(pane)
       paneElement.insertBefore(tabBarView.element, paneElement.firstChild)
@@ -32,6 +34,12 @@ module.exports =
       @tabBarViews.push(tabBarView)
       pane.onDidDestroy => _.remove(@tabBarViews, tabBarView)
 
+    state = [] # Reset state so it only affects the initial panes observed
+
   deactivate: ->
     @paneSubscription.dispose()
     tabBarView.remove() for tabBarView in @tabBarViews
+
+  serialize: ->
+    for tabBarView in @tabBarViews
+      previewTabURI: tabBarView.getPreviewTabURI()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -26,7 +26,7 @@ module.exports =
     _ = require 'underscore-plus'
 
     @paneSubscription = atom.workspace.observePanes (pane) =>
-      tabBarView = new TabBarView(pane, state.pop())
+      tabBarView = new TabBarView(pane, state.shift())
 
       paneElement = atom.views.getView(pane)
       paneElement.insertBefore(tabBarView.element, paneElement.firstChild)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -42,5 +42,5 @@ module.exports =
     return
 
   serialize: ->
-    for tabBarView in @tabBarViews
+    @tabBarViews.map (tabBarView) ->
       previewTabURI: tabBarView.getPreviewTabURI()

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -11,7 +11,7 @@ class TabBarView extends View
   @content: ->
     @ul tabindex: -1, class: "list-inline tab-bar inset-panel"
 
-  initialize: (@pane) ->
+  initialize: (@pane, state={}) ->
     @subscriptions = new CompositeDisposable
 
     @subscriptions.add atom.commands.add atom.views.getView(@pane),
@@ -36,7 +36,7 @@ class TabBarView extends View
 
     @paneContainer = @pane.getContainer()
     @addTabForItem(item) for item in @pane.getItems()
-    @setInitialPreviewTab()
+    @setInitialPreviewTab(state.previewTabURI)
 
     @subscriptions.add @pane.onDidDestroy =>
       @unsubscribe()
@@ -90,10 +90,14 @@ class TabBarView extends View
     RendererIpc.removeListener('tab:dropped', @onDropOnOtherWindow)
     @subscriptions.dispose()
 
-  setInitialPreviewTab: ->
-    activeItem = @pane.getActiveItem()
+  setInitialPreviewTab: (previewTabURI) ->
     for tab in @getTabs() when tab.isPreviewTab
-      tab.clearPreview() if tab.item isnt activeItem
+      tab.clearPreview() if tab.item.getURI() isnt previewTabURI
+    return
+
+  getPreviewTabURI: ->
+    for tab in @getTabs() when tab.isPreviewTab
+      return tab.item.getURI()
     return
 
   clearPreviewTabs: ->

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -43,7 +43,7 @@ describe "Tabs package main", ->
       expect(workspaceElement.querySelectorAll('.pane').length).toBe 3
       expect(workspaceElement.querySelectorAll('.pane > .tab-bar').length).toBe 0
 
-    fit "serializes preview tab state", ->
+    it "serializes preview tab state", ->
       atom.config.set('tabs.usePreviewTabs', true)
 
       waitsForPromise ->

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -866,7 +866,7 @@ describe "TabBarView", ->
           expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
 
     describe "when splitting a preview tab", ->
-      it "makes the tab permanent tab in the new pane", ->
+      it "makes the tab permanent in the new pane", ->
         editor1 = null
         waitsForPromise ->
           atom.project.open('sample.txt').then (o) -> editor1 = o

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -43,6 +43,28 @@ describe "Tabs package main", ->
       expect(workspaceElement.querySelectorAll('.pane').length).toBe 3
       expect(workspaceElement.querySelectorAll('.pane > .tab-bar').length).toBe 0
 
+    fit "serializes preview tab state", ->
+      atom.config.set('tabs.usePreviewTabs', true)
+
+      waitsForPromise ->
+        atom.workspace.open('sample.txt')
+
+      runs ->
+        expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 1
+        expect(workspaceElement.querySelector('.tab.preview-tab .title')?.textContent).toBe 'sample.txt'
+
+        atom.packages.deactivatePackage('tabs')
+
+        expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 0
+
+      waitsForPromise ->
+        atom.packages.activatePackage('tabs')
+
+      runs ->
+        expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 1
+        expect(workspaceElement.querySelector('.tab.preview-tab .title')?.textContent).toBe 'sample.txt'
+
+
 describe "TabBarView", ->
   [deserializerDisposable, item1, item2, editor1, pane, tabBar] = []
 

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -867,7 +867,7 @@ describe "TabBarView", ->
           expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
 
     describe "when splitting a preview tab", ->
-      it "makes the tab a preview tab in the new pane", ->
+      it "makes the tab permanent tab in the new pane", ->
         editor1 = null
         waitsForPromise ->
           atom.project.open('sample.txt').then (o) -> editor1 = o
@@ -877,4 +877,4 @@ describe "TabBarView", ->
           pane2 = pane.splitRight(copyActiveItem: true)
           tabBar2 = new TabBarView(pane2)
 
-          expect($(tabBar2.tabForItem(pane2.getActiveItem())).find('.title')).toHaveClass 'temp'
+          expect($(tabBar2.tabForItem(pane2.getActiveItem())).find('.title')).not.toHaveClass 'temp'

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -64,7 +64,6 @@ describe "Tabs package main", ->
         expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 1
         expect(workspaceElement.querySelector('.tab.preview-tab .title')?.textContent).toBe 'sample.txt'
 
-
 describe "TabBarView", ->
   [deserializerDisposable, item1, item2, editor1, pane, tabBar] = []
 


### PR DESCRIPTION
Serialize the preview tab URI across restarts so the right tab is marked as a preview tab when Atom starts.

This also changes the behavior to make split tabs permanent since that seems to be consistent with editing/double-clicking a tab making it permanent

Fixes https://github.com/atom/tabs/issues/154