### PR TITLE
Register close commands on pane level

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -17,6 +17,13 @@ class TabBarView extends View
     @subscriptions.add atom.commands.add atom.views.getView(@pane),
       'tabs:keep-preview-tab': => @clearPreviewTabs()
 
+    @subscriptions.add atom.commands.add 'atom-workspace',
+      'tabs:close-tab': => @closeTab()
+      'tabs:close-other-tabs': => @closeOtherTabs()
+      'tabs:close-tabs-to-right': => @closeTabsToRight()
+      'tabs:close-saved-tabs': => @closeSavedTabs()
+      'tabs:close-all-tabs': => @closeAllTabs()
+
     @subscriptions.add atom.commands.add @element,
       'tabs:close-tab': => @closeTab()
       'tabs:close-other-tabs': => @closeOtherTabs()
@@ -164,7 +171,8 @@ class TabBarView extends View
 
   closeTab: (tab) ->
     tab ?= @children('.right-clicked')[0]
-    @pane.destroyItem(tab.item)
+    tab ?= @tabForItem(@pane.getActiveItem())
+    @pane.destroyItem(tab.item) if tab?
 
   splitTab: (fn) ->
     if item = @children('.right-clicked')[0]?.item
@@ -177,12 +185,14 @@ class TabBarView extends View
   closeOtherTabs: ->
     tabs = @getTabs()
     active = @children('.right-clicked')[0]
+    active ?= @tabForItem(@pane.getActiveItem())
     return unless active?
     @closeTab tab for tab in tabs when tab isnt active
 
   closeTabsToRight: ->
     tabs = @getTabs()
     active = @children('.right-clicked')[0]
+    active ?= @tabForItem(@pane.getActiveItem())
     index = tabs.indexOf(active)
     return if index is -1
     @closeTab tab for tab, i in tabs when i > index

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -16,8 +16,6 @@ class TabBarView extends View
 
     @subscriptions.add atom.commands.add atom.views.getView(@pane),
       'tabs:keep-preview-tab': => @clearPreviewTabs()
-
-    @subscriptions.add atom.commands.add 'atom-workspace',
       'tabs:close-tab': => @closeTab(@getActiveTab())
       'tabs:close-other-tabs': => @closeOtherTabs(@getActiveTab())
       'tabs:close-tabs-to-right': => @closeTabsToRight(@getActiveTab())
@@ -167,6 +165,7 @@ class TabBarView extends View
       tabView.classList.add('active')
 
   getActiveTab: ->
+    console.log @pane.getActiveItem(), @tabForItem(@pane.getActiveItem())
     @tabForItem(@pane.getActiveItem())
 
   updateActiveTab: ->

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -165,7 +165,6 @@ class TabBarView extends View
       tabView.classList.add('active')
 
   getActiveTab: ->
-    console.log @pane.getActiveItem(), @tabForItem(@pane.getActiveItem())
     @tabForItem(@pane.getActiveItem())
 
   updateActiveTab: ->

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -18,9 +18,9 @@ class TabBarView extends View
       'tabs:keep-preview-tab': => @clearPreviewTabs()
 
     @subscriptions.add atom.commands.add 'atom-workspace',
-      'tabs:close-tab': => @closeTab()
-      'tabs:close-other-tabs': => @closeOtherTabs()
-      'tabs:close-tabs-to-right': => @closeTabsToRight()
+      'tabs:close-tab': => @closeTab(@getActiveTab())
+      'tabs:close-other-tabs': => @closeOtherTabs(@getActiveTab())
+      'tabs:close-tabs-to-right': => @closeTabsToRight(@getActiveTab())
       'tabs:close-saved-tabs': => @closeSavedTabs()
       'tabs:close-all-tabs': => @closeAllTabs()
 
@@ -166,12 +166,14 @@ class TabBarView extends View
       @element.querySelector('.tab.active')?.classList.remove('active')
       tabView.classList.add('active')
 
+  getActiveTab: ->
+    @tabForItem(@pane.getActiveItem())
+
   updateActiveTab: ->
     @setActiveTab(@tabForItem(@pane.getActiveItem()))
 
   closeTab: (tab) ->
     tab ?= @children('.right-clicked')[0]
-    tab ?= @tabForItem(@pane.getActiveItem())
     @pane.destroyItem(tab.item) if tab?
 
   splitTab: (fn) ->
@@ -182,17 +184,15 @@ class TabBarView extends View
   copyItem: (item) ->
     item.copy?() ? atom.deserializers.deserialize(item.serialize())
 
-  closeOtherTabs: ->
+  closeOtherTabs: (active) ->
     tabs = @getTabs()
-    active = @children('.right-clicked')[0]
-    active ?= @tabForItem(@pane.getActiveItem())
+    active ?= @children('.right-clicked')[0]
     return unless active?
     @closeTab tab for tab in tabs when tab isnt active
 
-  closeTabsToRight: ->
+  closeTabsToRight: (active) ->
     tabs = @getTabs()
-    active = @children('.right-clicked')[0]
-    active ?= @tabForItem(@pane.getActiveItem())
+    active ?= @children('.right-clicked')[0]
     index = tabs.indexOf(active)
     return if index is -1
     @closeTab tab for tab, i in tabs when i > index

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -432,29 +432,29 @@ describe "TabBarView", ->
         expect(atom.workspace.getPanes()[1].getItems()[0].getTitle()).toBe item2.getTitle()
 
   describe "command palette commands", ->
-    workspaceElement = null
+    paneElement = null
 
     beforeEach ->
-      workspaceElement = atom.views.getView(atom.workspace)
+      paneElement = atom.views.getView(pane)
 
     describe "when tabs:close-tab is fired", ->
       it "closes the active tab", ->
-        atom.commands.dispatch(workspaceElement, 'tabs:close-tab')
+        atom.commands.dispatch(paneElement, 'tabs:close-tab')
         expect(pane.getItems().length).toBe 2
         expect(pane.getItems().indexOf(item2)).toBe -1
         expect(tabBar.getTabs().length).toBe 2
         expect(tabBar.find('.tab:contains(Item 2)')).not.toExist()
 
       it "does nothing if no tabs are open", ->
-        atom.commands.dispatch(workspaceElement, 'tabs:close-tab')
-        atom.commands.dispatch(workspaceElement, 'tabs:close-tab')
-        atom.commands.dispatch(workspaceElement, 'tabs:close-tab')
+        atom.commands.dispatch(paneElement, 'tabs:close-tab')
+        atom.commands.dispatch(paneElement, 'tabs:close-tab')
+        atom.commands.dispatch(paneElement, 'tabs:close-tab')
         expect(pane.getItems().length).toBe 0
         expect(tabBar.getTabs().length).toBe 0
 
     describe "when tabs:close-other-tabs is fired", ->
       it "closes all other tabs except the active tab", ->
-        atom.commands.dispatch(workspaceElement, 'tabs:close-other-tabs')
+        atom.commands.dispatch(paneElement, 'tabs:close-other-tabs')
         expect(pane.getItems().length).toBe 1
         expect(tabBar.getTabs().length).toBe 1
         expect(tabBar.find('.tab:contains(sample.js)')).not.toExist()
@@ -463,7 +463,7 @@ describe "TabBarView", ->
     describe "when tabs:close-tabs-to-right is fired", ->
       it "closes only the tabs to the right of the active tab", ->
         pane.activateItem(editor1)
-        atom.commands.dispatch(workspaceElement, 'tabs:close-tabs-to-right')
+        atom.commands.dispatch(paneElement, 'tabs:close-tabs-to-right')
         expect(pane.getItems().length).toBe 2
         expect(tabBar.getTabs().length).toBe 2
         expect(tabBar.find('.tab:contains(Item 2)')).not.toExist()
@@ -472,13 +472,13 @@ describe "TabBarView", ->
     describe "when tabs:close-all-tabs is fired", ->
       it "closes all the tabs", ->
         expect(pane.getItems().length).toBeGreaterThan 0
-        atom.commands.dispatch(workspaceElement, 'tabs:close-all-tabs')
+        atom.commands.dispatch(paneElement, 'tabs:close-all-tabs')
         expect(pane.getItems().length).toBe 0
 
     describe "when tabs:close-saved-tabs is fired", ->
       it "closes all the saved tabs", ->
         item1.isModified = -> true
-        atom.commands.dispatch(workspaceElement, 'tabs:close-saved-tabs')
+        atom.commands.dispatch(paneElement, 'tabs:close-saved-tabs')
         expect(pane.getItems().length).toBe 1
         expect(pane.getItems()[0]).toBe item1
 

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -431,6 +431,57 @@ describe "TabBarView", ->
         expect(atom.workspace.getPanes()[0]).toBe pane
         expect(atom.workspace.getPanes()[1].getItems()[0].getTitle()).toBe item2.getTitle()
 
+  describe "command palette commands", ->
+    workspaceElement = null
+
+    beforeEach ->
+      workspaceElement = atom.views.getView(atom.workspace)
+
+    describe "when tabs:close-tab is fired", ->
+      it "closes the active tab", ->
+        atom.commands.dispatch(workspaceElement, 'tabs:close-tab')
+        expect(pane.getItems().length).toBe 2
+        expect(pane.getItems().indexOf(item2)).toBe -1
+        expect(tabBar.getTabs().length).toBe 2
+        expect(tabBar.find('.tab:contains(Item 2)')).not.toExist()
+
+      it "does nothing if no tabs are open", ->
+        atom.commands.dispatch(workspaceElement, 'tabs:close-tab')
+        atom.commands.dispatch(workspaceElement, 'tabs:close-tab')
+        atom.commands.dispatch(workspaceElement, 'tabs:close-tab')
+        expect(pane.getItems().length).toBe 0
+        expect(tabBar.getTabs().length).toBe 0
+
+    describe "when tabs:close-other-tabs is fired", ->
+      it "closes all other tabs except the active tab", ->
+        atom.commands.dispatch(workspaceElement, 'tabs:close-other-tabs')
+        expect(pane.getItems().length).toBe 1
+        expect(tabBar.getTabs().length).toBe 1
+        expect(tabBar.find('.tab:contains(sample.js)')).not.toExist()
+        expect(tabBar.find('.tab:contains(Item 2)')).toExist()
+
+    describe "when tabs:close-tabs-to-right is fired", ->
+      it "closes only the tabs to the right of the active tab", ->
+        pane.activateItem(editor1)
+        atom.commands.dispatch(workspaceElement, 'tabs:close-tabs-to-right')
+        expect(pane.getItems().length).toBe 2
+        expect(tabBar.getTabs().length).toBe 2
+        expect(tabBar.find('.tab:contains(Item 2)')).not.toExist()
+        expect(tabBar.find('.tab:contains(Item 1)')).toExist()
+
+    describe "when tabs:close-all-tabs is fired", ->
+      it "closes all the tabs", ->
+        expect(pane.getItems().length).toBeGreaterThan 0
+        atom.commands.dispatch(workspaceElement, 'tabs:close-all-tabs')
+        expect(pane.getItems().length).toBe 0
+
+    describe "when tabs:close-saved-tabs is fired", ->
+      it "closes all the saved tabs", ->
+        item1.isModified = -> true
+        atom.commands.dispatch(workspaceElement, 'tabs:close-saved-tabs')
+        expect(pane.getItems().length).toBe 1
+        expect(pane.getItems()[0]).toBe item1
+
   describe "dragging and dropping tabs", ->
     describe "when a tab is dragged within the same pane", ->
       describe "when it is dropped on tab that's later in the list", ->


### PR DESCRIPTION
Basically does the same as #121, but with working context menu commands and added specs.

This makes the commands for closing tabs available from the command palette anywhere in the `atom-workspace` scope. This makes it possible to add keybindings for things like "Close other tabs" etc. or closing all tabs on startup.

Addresses #61.