### PR TITLE
Fix tabs not showing VCS status when parent is symlink

### DIFF
--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -195,7 +195,8 @@ class TabView extends HTMLElement
       @updateVcsStatus(repo)
     .catch (err) ->
       # We can only get here if repository is destroyed
-      # by the time the promise is resolved
+      # by the time the promise is resolved.
+      # This happens during tests
 
   # Subscribe to the project's repo for changes to the VCS status of the file.
   subscribeToRepo: (repo) ->

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -193,10 +193,6 @@ class TabView extends HTMLElement
     @repoForPath(@path).then (repo) =>
       @subscribeToRepo(repo)
       @updateVcsStatus(repo)
-    .catch (err) ->
-      # We can only get here if repository is destroyed
-      # by the time the promise is resolved.
-      # This happens during tests
 
   # Subscribe to the project's repo for changes to the VCS status of the file.
   subscribeToRepo: (repo) ->


### PR DESCRIPTION
Fixes https://github.com/atom/tabs/issues/182.
Also, replaces use of `atom.project.getRepositories`, which will be removed in version 2.0, for `atom.project.repositoryForDirectory`