### PR TITLE
Change tab from preview to permanent when press enter on file in the tree view

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -117,6 +117,11 @@ class TabBarView extends View
         @tabForItem(@pane.itemForURI(itemPath))?.clearPreview()
 
     $(document.body).on('dblclick', treeViewSelector, clearPreviewTabForFile)
+
+    atom.commands.add '.tree-view',
+      'tree-view:open-selected-entry': ({target}) =>
+        @clearPreviewTabs()
+
     @subscriptions.add dispose: ->
       $(document.body).off('dblclick', treeViewSelector, clearPreviewTabForFile)
 

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -100,7 +100,7 @@ class TabBarView extends HTMLElement
       if itemPath = target.dataset.path
         @tabForItem(@pane.itemForURI(itemPath))?.clearPreview()
 
-    $(document.body).on('dblclick', treeViewSelector, clearPreviewTabForFile)
+    document.body.addEventListener('dblclick', clearPreviewTabForFile)
 
     atom.commands.add '.tree-view',
       'tree-view:open-selected-entry': ({target}) =>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabs",
-  "version": "0.80.0",
+  "version": "0.81.0",
   "main": "./lib/main",
   "description": "Display a selectable tab for each editor open.",
   "license": "MIT",

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -1008,6 +1008,33 @@ describe "TabBarView", ->
 
           expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'
 
+    describe "when press enter on a file in the tree view", ->
+      it "makes the tab for that file permanent", ->
+        editor1 = null
+        workspaceElement = atom.views.getView(atom.workspace)
+        jasmine.attachToDOM(workspaceElement)
+
+        waitsForPromise ->
+          atom.packages.activatePackage('tree-view')
+
+        runs ->
+          atom.commands.dispatch(workspaceElement, 'tree-view:show')
+
+        waitsFor ->
+          workspaceElement.querySelector('.tree-view')
+
+        waitsForPromise ->
+          atom.project.open('sample.js').then (o) -> editor1 = o
+
+        runs ->
+          pane.activateItem(editor1)
+
+          expect($(tabBar.tabForItem(editor1)).find('.title')).toHaveClass 'temp'
+
+          fileNode = workspaceElement.querySelector(".tree-view [data-path=\"#{path.join(__dirname, 'fixtures', 'sample.js')}\"]")
+          atom.commands.dispatch(fileNode, 'tree-view:open-selected-entry')
+          expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'
+
   describe "integration with version control systems", ->
     [repository, tab, tab1] = []
 

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -1029,31 +1029,16 @@ describe "TabBarView", ->
     describe "when double clicking a file in the tree view", ->
       it "makes the tab for that file permanent", ->
         editor1 = null
-        workspaceElement = atom.views.getView(atom.workspace)
-        jasmine.attachToDOM(workspaceElement)
-
-        waitsForPromise ->
-          atom.packages.activatePackage('tree-view')
-
-        runs ->
-          atom.commands.dispatch(workspaceElement, 'tree-view:show')
-
-        waitsFor ->
-          workspaceElement.querySelector('.tree-view')
 
         waitsForPromise ->
           atom.workspace.open('sample.js').then (o) -> editor1 = o
 
         runs ->
           pane.activateItem(editor1)
-
           expect($(tabBar.tabForItem(editor1)).find('.title')).toHaveClass 'temp'
-
-          fileNode = workspaceElement.querySelector(".tree-view [data-path=\"#{path.join(__dirname, 'fixtures', 'sample.js')}\"]")
-          fileNode.dispatchEvent(new MouseEvent('click', detail: 1, bubbles: true, cancelable: true))
-          fileNode.dispatchEvent(new MouseEvent('click', detail: 2, bubbles: true, cancelable: true))
-          fileNode.dispatchEvent(new MouseEvent('dblclick', detail: 2, bubbles: true, cancelable: true))
-
+          dbclickEvt = document.createEvent 'MouseEvents'
+          dbclickEvt.initEvent 'dblclick'
+          tabBar.tabForItem(editor1).dispatchEvent dbclickEvt
           expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'
 
     describe "when press enter on a file in the tree view", ->


### PR DESCRIPTION
Similar to how double-clicking on a file makes it a working file, pressing the enter key on the file should do the same.

Right now, if Preview Tabs is on and you press enter to select a file, it goes into a preview pane, which is counter-intuitive.  This commit fixes it so when you select a file by pressing enter, it treats that selection as a working file and opens it in a permanent pane.
