### PR TITLE
Make double click in Project Find Results make tabs permanent.

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -73,6 +73,7 @@ class TabBarView extends View
     @subscriptions.add atom.config.observe 'tabs.alwaysShowTabBar', => @updateTabBarVisibility()
 
     @handleTreeViewEvents()
+    @handleFindAndReplaceEvents()
 
     @updateActiveTab()
 
@@ -119,6 +120,21 @@ class TabBarView extends View
     $(document.body).on('dblclick', treeViewSelector, clearPreviewTabForFile)
     @subscriptions.add dispose: ->
       $(document.body).off('dblclick', treeViewSelector, clearPreviewTabForFile)
+
+  handleFindAndReplaceEvents: ->
+    findAndReplaceViewSelector = '.results-view li.search-result[is=space-pen-li]'
+    clearPreviewTabForFile = ({target}) =>
+      return unless @pane.isFocused()
+
+      target = $(target).closest('[data-path]')
+      if itemPath = target?[0]?.dataset.path
+        @tabForItem(@pane.itemForURI(itemPath))?.clearPreview()
+
+    $(document.body).on(
+      'dblclick', findAndReplaceViewSelector, clearPreviewTabForFile)
+    @subscriptions.add dispose: ->
+      $(document.body).off(
+        'dblclick', findAndReplaceViewSelector, clearPreviewTabForFile)
 
   setInitialPreviewTab: (previewTabURI) ->
     for tab in @getTabs() when tab.isPreviewTab

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -1116,3 +1116,60 @@ describe "TabBarView", ->
 
         runs ->
           expect(tabBar.find('.tab:eq(1) .title')).toHaveClass "status-modified"
+
+describe 'TabBarView and find-and-replace', ->
+  describe "when double clicking a result in the Project Find Results", ->
+    [activationPromise, projectFindView, searchPromise, workspaceElement, firstResult] = []
+
+    beforeEach ->
+      workspaceElement = atom.views.getView(atom.workspace)
+      atom.project.setPaths([path.join(__dirname, 'fixtures')])
+      jasmine.attachToDOM(workspaceElement)
+
+      activationPromise = atom.packages.activatePackage("find-and-replace").then ({mainModule}) ->
+        mainModule.createViews()
+        {projectFindView} = mainModule
+        spy = spyOn(projectFindView, 'confirm').andCallFake ->
+          searchPromise = spy.originalValue.call(projectFindView)
+          searchPromise
+
+    beforeEach ->
+      atom.config.set('find-and-replace.openProjectFindResultsInRightPane', true)
+      atom.config.set('tabs.usePreviewTabs', true)
+      atom.commands.dispatch(workspaceElement, 'project-find:show')
+
+      waitsForPromise ->
+        atom.packages.activatePackage("tabs")
+
+      waitsForPromise ->
+        activationPromise
+
+      runs ->
+        projectFindView.findEditor.setText('items')
+        atom.commands.dispatch(projectFindView[0], 'core:confirm')
+
+      waitsForPromise ->
+        searchPromise
+
+      runs ->
+        expect(atom.workspace.getTextEditors().length).toBe 0
+
+        firstResult = workspaceElement.querySelectorAll('.results-view .search-result')[0]
+        firstResult.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, cancelable: true}))
+        firstResult.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, cancelable: true}))
+        firstResult.dispatchEvent(new MouseEvent('click', {detail: 1, bubbles: true, cancelable: true}))
+
+      waitsFor ->
+        atom.workspace.getTextEditors().length is 1
+
+      runs ->
+        expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 1
+        firstResult.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, cancelable: true}))
+        firstResult.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, cancelable: true}))
+        firstResult.dispatchEvent(new MouseEvent('click', {detail: 2, bubbles: true, cancelable: true}))
+        firstResult.dispatchEvent(new MouseEvent('dblclick', {detail: 2, bubbles: true, cancelable: true}))
+
+    it 'makes the tab for that file permanent', ->
+      waitsFor( ->
+        workspaceElement.querySelectorAll('.tab.preview-tab .title').length is 0
+      , 'clearing preview', 1000)


### PR DESCRIPTION
Make double clicking a result of Project Find Results make the tab of its file permanent.

This makes its behavior consistent with #156 .
