### PR TITLE
Warn when disposables outside our control are not valid

### DIFF
--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -44,7 +44,7 @@ class TabView extends HTMLElement
       if Disposable.isDisposable(onDidChangeTitleDisposable)
         @subscriptions.add(onDidChangeTitleDisposable)
       else
-        console.warn "::onDidChangeTitle does not return a valid Disposable!"
+        console.warn "::onDidChangeTitle does not return a valid Disposable!", @item
     else if typeof @item.on is 'function'
       #TODO Remove once old events are no longer supported
       @item.on('title-changed', titleChangedHandler)
@@ -60,7 +60,7 @@ class TabView extends HTMLElement
       if Disposable.isDisposable(onDidChangeIconDisposable)
         @subscriptions.add(onDidChangeIconDisposable)
       else
-        console.warn "::onDidChangeIcon does not return a valid Disposable!"
+        console.warn "::onDidChangeIcon does not return a valid Disposable!", @item
     else if typeof @item.on is 'function'
       #TODO Remove once old events are no longer supported
       @item.on('icon-changed', iconChangedHandler)
@@ -75,7 +75,7 @@ class TabView extends HTMLElement
       if Disposable.isDisposable(onDidChangeModifiedDisposable)
         @subscriptions.add(onDidChangeModifiedDisposable)
       else
-        console.warn "::onDidChangeModified does not return a valid Disposable!"
+        console.warn "::onDidChangeModified does not return a valid Disposable!", @item
     else if typeof @item.on is 'function'
       #TODO Remove once old events are no longer supported
       @item.on('modified-status-changed', modifiedHandler)
@@ -92,7 +92,7 @@ class TabView extends HTMLElement
       if Disposable.isDisposable(onDidSaveDisposable)
         @subscriptions.add(onDidSaveDisposable)
       else
-        console.warn "::onDidSave does not return a valid Disposable!"
+        console.warn "::onDidSave does not return a valid Disposable!", @item
     @subscriptions.add atom.config.observe 'tabs.showIcons', =>
       @updateIconVisibility()
 

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -44,7 +44,7 @@ class TabView extends HTMLElement
       if Disposable.isDisposable(onDidChangeTitleDisposable)
         @subscriptions.add(onDidChangeTitleDisposable)
       else
-        console.warn "::onDidChangeTitle does not return a valid disposable!"
+        console.warn "::onDidChangeTitle does not return a valid Disposable!"
     else if typeof @item.on is 'function'
       #TODO Remove once old events are no longer supported
       @item.on('title-changed', titleChangedHandler)
@@ -55,8 +55,12 @@ class TabView extends HTMLElement
       @updateIcon()
 
     if typeof @item.onDidChangeIcon is 'function'
-      @subscriptions.add @item.onDidChangeIcon? =>
+      onDidChangeIconDisposable = @item.onDidChangeIcon? =>
         @updateIcon()
+      if Disposable.isDisposable(onDidChangeIconDisposable)
+        @subscriptions.add(onDidChangeIconDisposable)
+      else
+        console.warn "::onDidChangeIcon does not return a valid Disposable!"
     else if typeof @item.on is 'function'
       #TODO Remove once old events are no longer supported
       @item.on('icon-changed', iconChangedHandler)
@@ -71,7 +75,7 @@ class TabView extends HTMLElement
       if Disposable.isDisposable(onDidChangeModifiedDisposable)
         @subscriptions.add(onDidChangeModifiedDisposable)
       else
-        console.warn "::onDidChangeModified does not return a valid disposable!"
+        console.warn "::onDidChangeModified does not return a valid Disposable!"
     else if typeof @item.on is 'function'
       #TODO Remove once old events are no longer supported
       @item.on('modified-status-changed', modifiedHandler)
@@ -79,12 +83,16 @@ class TabView extends HTMLElement
         @item.off?('modified-status-changed', modifiedHandler)
 
     if typeof @item.onDidSave is 'function'
-      @subscriptions.add @item.onDidSave (event) =>
+      onDidSaveDisposable = @item.onDidSave (event) =>
         @clearPreview()
         if event.path isnt @path
           @path = event.path
           @setupVcsStatus() if atom.config.get 'tabs.enableVcsColoring'
 
+      if Disposable.isDisposable(onDidSaveDisposable)
+        @subscriptions.add(onDidSaveDisposable)
+      else
+        console.warn "::onDidSave does not return a valid Disposable!"
     @subscriptions.add atom.config.observe 'tabs.showIcons', =>
       @updateIconVisibility()
 

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -1,6 +1,6 @@
 path = require 'path'
 {$} = require 'atom-space-pen-views'
-{CompositeDisposable} = require 'atom'
+{Disposable, CompositeDisposable} = require 'atom'
 
 module.exports =
 class TabView extends HTMLElement
@@ -40,7 +40,11 @@ class TabView extends HTMLElement
       @updateTooltip()
 
     if typeof @item.onDidChangeTitle is 'function'
-      @subscriptions.add @item.onDidChangeTitle(titleChangedHandler)
+      onDidChangeTitleDisposable = @item.onDidChangeTitle(titleChangedHandler)
+      if Disposable.isDisposable(onDidChangeTitleDisposable)
+        @subscriptions.add(onDidChangeTitleDisposable)
+      else
+        console.warn "::onDidChangeTitle does not return a valid disposable!"
     else if typeof @item.on is 'function'
       #TODO Remove once old events are no longer supported
       @item.on('title-changed', titleChangedHandler)
@@ -63,7 +67,11 @@ class TabView extends HTMLElement
       @updateModifiedStatus()
 
     if typeof @item.onDidChangeModified is 'function'
-      @subscriptions.add @item.onDidChangeModified(modifiedHandler)
+      onDidChangeModifiedDisposable = @item.onDidChangeModified(modifiedHandler)
+      if Disposable.isDisposable(onDidChangeModifiedDisposable)
+        @subscriptions.add(onDidChangeModifiedDisposable)
+      else
+        console.warn "::onDidChangeModified does not return a valid disposable!"
     else if typeof @item.on is 'function'
       #TODO Remove once old events are no longer supported
       @item.on('modified-status-changed', modifiedHandler)

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -133,6 +133,34 @@ describe "TabBarView", ->
     it "highlights the tab for the active pane item", ->
       expect(tabBar.find('.tab:eq(2)')).toHaveClass 'active'
 
+    it "emits a warning when ::onDid... functions are not valid Disposables", ->
+      class BadView extends View
+        @content: (title) -> @div title
+        getTitle: -> "Anything"
+        onDidChangeTitle: ->
+        onDidChangeIcon: ->
+        onDidChangeModified: ->
+        onDidSave: ->
+
+      warnings = []
+      spyOn(console, "warn").andCallFake (message, object) ->
+        warnings.push({message: message, object: object})
+
+      badItem = new BadView('Item 3')
+      pane.addItem(badItem)
+
+      expect(warnings[0].message).toContain("onDidChangeTitle")
+      expect(warnings[0].object).toBe(badItem)
+
+      expect(warnings[1].message).toContain("onDidChangeIcon")
+      expect(warnings[1].object).toBe(badItem)
+
+      expect(warnings[2].message).toContain("onDidChangeModified")
+      expect(warnings[2].object).toBe(badItem)
+
+      expect(warnings[3].message).toContain("onDidSave")
+      expect(warnings[3].object).toBe(badItem)
+
   describe "when the active pane item changes", ->
     it "highlights the tab for the new active pane item", ->
       pane.activateItem(item1)

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -144,7 +144,7 @@ describe "TabBarView", ->
 
       warnings = []
       spyOn(console, "warn").andCallFake (message, object) ->
-        warnings.push({message: message, object: object})
+        warnings.push({message, object})
 
       badItem = new BadView('Item 3')
       pane.addItem(badItem)


### PR DESCRIPTION
Fixes https://github.com/atom/tabs/issues/183.

I haven't added tests for these changes as I feel like it's fine to verify just the *happy path* (which is already covered by existing specs). Manual testing confirmed this plays nicely with git-log and the aforementioned issue.

Thoughts? :thought_balloon: I must admit I am not super in :heart: with the code, as it adds a bit of complexity to an otherwise straightforward conditional logic. What do you think?

Thanks!

/cc: @kevinsawicki @maxbrunsfeld @nathansobo