### PR TITLE
Add 'Close All Tabs' to File menu

### DIFF
--- a/menus/tabs.cson
+++ b/menus/tabs.cson
@@ -1,3 +1,12 @@
+menu: [
+  {
+    label: 'File'
+    submenu: [
+      {label: 'Close All Tabs', command: 'tabs:close-all-tabs'}
+    ]
+  }
+]
+
 'context-menu':
   '.tab': [
     {label: 'Close Tab', command: 'tabs:close-tab'}


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/3111#issuecomment-135111791

Ordering of menu items here is not ideal (it should be directly under File > Close Tab), but that's blocked on https://github.com/atom/atom/issues/6270.

/cc @atom/feedback 