### PR TITLE
Add ability to create a new window by dragging a tab out or using right click menu on tab

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.
 
 git:
   depth: 10
+
+branches:
+  only:
+    - master

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabs",
-  "version": "0.83.0",
+  "version": "0.84.0",
   "main": "./lib/main",
   "description": "Display a selectable tab for each editor open.",
   "license": "MIT",

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -1,3 +1,4 @@
+BrowserWindow = null
 {$, View}  = require 'atom-space-pen-views'
 _ = require 'underscore-plus'
 path = require 'path'
@@ -672,6 +673,22 @@ describe "TabBarView", ->
         expect(dragStartEvent.originalEvent.dataTransfer.getData("text/plain")).toEqual editor1.getPath()
         if process.platform is 'darwin'
           expect(dragStartEvent.originalEvent.dataTransfer.getData("text/uri-list")).toEqual "file://#{editor1.getPath()}"
+
+      it "should open a new window if the target doesn't handle the file information", ->
+        [dragStartEvent, dropEvent] = buildDragEvents(tabBar.tabAtIndex(1), tabBar.tabAtIndex(0))
+        expect(pane.getActiveItem()).toBe item2
+        spyOn(tabBar, "openTabInNewWindow").andCallThrough()
+        BrowserWindow ?= require('remote').require('browser-window')
+
+        tabBar.onDragStart(dragStartEvent)
+        dropEvent.originalEvent.dataTransfer.dropEffect = "none"
+        dropEvent.originalEvent.screenX = 10
+        dropEvent.originalEvent.screenY = 20
+        tabBar.onDragEnd(dropEvent)
+
+        expect(BrowserWindow.getAllWindows().length).toBe (windowCount + 1)
+        expect(tabBar.openTabInNewWindow).toHaveBeenCalledWith(dropEvent.target, 10, 20)
+
 
     describe "when a tab is dragged to another Atom window", ->
       it "closes the tab in the first window and opens the tab in the second window", ->


### PR DESCRIPTION
Fixes #39, by adding the ability to popout a tab into a new window.

When dropping a tab it just checks if the thing that it is being dropped on does not handle the drop. So it only works if the drop effect of the item that it is hovering is "none." That way if you drop the tab onto an application that can handle the link then it doesn't create a new window. 

The window is opened using the atom command "application:new-window", which creates a new window that has one Untitled tab. The Untitled tab is then closed and the tab that the user is opening is loaded. If the item being opened in a new window has unsaved changes, they will be moved over to the new window and the tab that is left behind will be closed without warning about unsaved changes. 

Dragged and dropped windows try to open at the screen location that they were dropped. That code can be removed if you want to just have it open where ever the atom new-window command would put it.

This open tab in new window code has the same problem as the drag and drop tabs into an existing window code, where Markdown Preview and Project Find Results are blank. This seems to be a problem those packages and not something the tabs package should fix.

## Context Menu Example
![contextmenunewwindow](https://cloud.githubusercontent.com/assets/65763/9925844/f0838f80-5cc4-11e5-9191-30d1fee463c0.gif)

## Drag and Drop Example 
![dragtocreatewindow](https://cloud.githubusercontent.com/assets/65763/9925845/f086b138-5cc4-11e5-8d70-3ebd594fcdfe.gif)


