### PR TITLE
Make tab opening position at end option

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -21,6 +21,10 @@ module.exports =
       title: "Enable VCS Coloring"
       type: 'boolean'
       default: false
+    alwaysOpenNewTabAtEnd:
+      type: 'boolean'
+      default: false
+      description: 'New tabs will be inserted at the end of the current list of tabs'
 
   activate: (state) ->
     state = [] unless Array.isArray(state)

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -149,7 +149,10 @@ class TabBarView extends View
     tabView.initialize(item)
     tabView.clearPreview() if @isItemMovingBetweenPanes
     @storePreviewTabToDestroy() if tabView.isPreviewTab
-    @insertTabAtIndex(tabView, index)
+    if not atom.config.get('tabs.alwaysOpenNewTabAtEnd')
+      @insertTabAtIndex(tabView, index)
+    else
+      @insertTabAtIndex(tabView)
 
   moveItemTabToIndex: (item, index) ->
     if tab = @tabForItem(item)

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -172,12 +172,24 @@ describe "TabBarView", ->
       expect(tabBar.find('.tab:eq(2)')).toHaveClass 'active'
 
   describe "when a new item is added to the pane", ->
-    it "adds a tab for the new item at the same index as the item in the pane", ->
-      pane.activateItem(item1)
-      item3 = new TestView('Item 3')
-      pane.activateItem(item3)
-      expect(tabBar.find('.tab').length).toBe 4
-      expect($(tabBar.tabAtIndex(1)).find('.title')).toHaveText 'Item 3'
+    describe "when alwaysOpenNewTabAtEnd is false in package settings", ->
+      it "adds a tab for the new item at the same index as the item in the pane", ->
+        atom.config.set("tabs.alwaysOpenNewTabAtEnd", false)
+        pane.activateItem(item1)
+        item3 = new TestView('Item 3')
+        pane.activateItem(item3)
+        expect(tabBar.find('.tab').length).toBe 4
+        expect($(tabBar.tabAtIndex(1)).find('.title')).toHaveText 'Item 3'
+
+    describe "when alwaysOpenNewTabAtEnd is true in package settings", ->
+      it "adds a tab for the new item as the last item in the bar", ->
+        atom.config.set("tabs.alwaysOpenNewTabAtEnd", true)
+        pane.activateItem(item1)
+        item3 = new TestView('Item 3')
+        pane.activateItem(item3)
+        expect(tabBar.find('.tab').length).toBe 4
+        expect($(tabBar.tabAtIndex(1)).find('.title')).toHaveText 'sample.js'
+        expect($(tabBar.tabAtIndex(3)).find('.title')).toHaveText 'Item 3'
 
     it "adds the 'modified' class to the new tab if the item is initially modified", ->
       editor2 = null


### PR DESCRIPTION
Some people (me!) like new tabs to sit at the end of the tab list, not next to the current tab.

This PR adds an option "Always open new tab at end" to the tabs package settings.

This was briefly discussed at https://discuss.atom.io/t/newly-opened-tab-order/20822