### PR TITLE
Loosen selector to class names to allow integration

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -107,7 +107,7 @@ class TabBarView extends View
     @subscriptions.dispose()
 
   handleTreeViewEvents: ->
-    treeViewSelector = '.tree-view li[is=tree-view-file]'
+    treeViewSelector = '.tree-view .entry.file'
     clearPreviewTabForFile = ({target}) =>
       return unless @pane.isFocused()
 


### PR DESCRIPTION
`[is=tree-view-file]` enables only the custom element that registered as
`tree-view-file` to integrate with this package's preview tabs feature.
Using `.file-tree .entry.file` allows other file tree implementations to
match the selector without having to commandeer the globally-unique
"tree-view-file" custom element name.

Fixes #208