### PR TITLE
Improve performance of `updateActiveTab`

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -177,7 +177,7 @@ class TabBarView extends View
       @element.classList.remove('hidden')
 
   getTabs: ->
-    @children('.tab').toArray()
+    Array.prototype.slice.call(@element.getElementsByClassName('tab'))
 
   tabAtIndex: (index) ->
     @children(".tab:eq(#{index})")[0]
@@ -185,16 +185,14 @@ class TabBarView extends View
   tabForItem: (item) ->
     _.detect @getTabs(), (tab) -> tab.item is item
 
-  setActiveTab: (tabView) ->
-    if tabView? and not tabView.classList.contains('active')
-      @element.querySelector('.tab.active')?.classList.remove('active')
-      tabView.classList.add('active')
-
   getActiveTab: ->
     @tabForItem(@pane.getActiveItem())
 
   updateActiveTab: ->
-    @setActiveTab(@tabForItem(@pane.getActiveItem()))
+    activeItem = @pane.getActiveItem()
+    if activeItem?
+      @getTabs().forEach (tab) ->
+        tab.classList.toggle('active', tab.item is activeItem)
 
   closeTab: (tab) ->
     tab ?= @children('.right-clicked')[0]


### PR DESCRIPTION
* Use native `element.getElementsByClassName`, cut out jQuery, to get
  all tabs. jQuery is nearly 100% slower than `getElementsByClassName`:
  https://jsperf.com/getelementsbyclassname-vs-queryselectorall/155
* Iterate all tabs only once when setting new active tab. `tabForItem`
  fetched and iterated all tabs once, as did `setActiveTab`, and the DOM
  was queried several times. Reduce to a single `getTabs` call (a single
  DOM query), and iterate the collection only once.

Typical slices of jQuery that appear in profiles when switching tabs are below. The stacks no longer appear with this change:

<img width="295" alt="" src="https://cloud.githubusercontent.com/assets/29612/10639538/dd6c619e-77de-11e5-9228-02357d7c06d4.png">

<img width="203" alt="" src="https://cloud.githubusercontent.com/assets/29612/10639512/bcb2051c-77de-11e5-90a7-0d60ecd8ea1d.png">
