### PR TITLE
Listen to path changed event in addition to title changed

### DIFF
--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -33,22 +33,22 @@ class TabView extends HTMLElement
       @addEventListener 'dblclick', => @clearPreview()
 
   handleEvents: ->
-    titleChangedHandler = =>
+    pathChangedHandler = (@path) =>
       @updateDataAttributes()
       @updateTitle()
       @updateTooltip()
 
-    if typeof @item.onDidChangeTitle is 'function'
-      onDidChangeTitleDisposable = @item.onDidChangeTitle(titleChangedHandler)
-      if Disposable.isDisposable(onDidChangeTitleDisposable)
-        @subscriptions.add(onDidChangeTitleDisposable)
+    if typeof @item.onDidChangePath is 'function'
+      onDidChangePathDisposable = @item.onDidChangePath(pathChangedHandler)
+      if Disposable.isDisposable(onDidChangePathDisposable)
+        @subscriptions.add(onDidChangePathDisposable)
       else
-        console.warn "::onDidChangeTitle does not return a valid Disposable!", @item
+        console.warn "::onDidChangePath does not return a valid Disposable!", @item
     else if typeof @item.on is 'function'
       #TODO Remove once old events are no longer supported
-      @item.on('title-changed', titleChangedHandler)
+      @item.on('path-changed', pathChangedHandler)
       @subscriptions.add dispose: =>
-        @item.off?('title-changed', titleChangedHandler)
+        @item.off?('path-changed', pathChangedHandler)
 
     iconChangedHandler = =>
       @updateIcon()

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -33,6 +33,21 @@ class TabView extends HTMLElement
       @addEventListener 'dblclick', => @clearPreview()
 
   handleEvents: ->
+    titleChangedHandler = =>
+      @updateTitle()
+
+    if typeof @item.onDidChangeTitle is 'function'
+      onDidChangeTitleDisposable = @item.onDidChangeTitle(titleChangedHandler)
+      if Disposable.isDisposable(onDidChangeTitleDisposable)
+        @subscriptions.add(onDidChangeTitleDisposable)
+      else
+        console.warn "::onDidChangeTitle does not return a valid Disposable!", @item
+    else if typeof @item.on is 'function'
+      #TODO Remove once old events are no longer supported
+      @item.on('title-changed', titleChangedHandler)
+      @subscriptions.add dispose: =>
+        @item.off?('title-changed', titleChangedHandler)
+
     pathChangedHandler = (@path) =>
       @updateDataAttributes()
       @updateTitle()

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -154,16 +154,16 @@ describe "TabBarView", ->
       expect(warnings[0].message).toContain("onDidChangeTitle")
       expect(warnings[0].object).toBe(badItem)
 
-      expect(warnings[1].message).toContain("onDidChangeIcon")
+      expect(warnings[1].message).toContain("onDidChangePath")
       expect(warnings[1].object).toBe(badItem)
 
-      expect(warnings[2].message).toContain("onDidChangeModified")
+      expect(warnings[2].message).toContain("onDidChangeIcon")
       expect(warnings[2].object).toBe(badItem)
 
-      expect(warnings[3].message).toContain("onDidSave")
+      expect(warnings[3].message).toContain("onDidChangeModified")
       expect(warnings[3].object).toBe(badItem)
 
-      expect(warnings[4].message).toContain("onDidChangePath")
+      expect(warnings[4].message).toContain("onDidSave")
       expect(warnings[4].object).toBe(badItem)
 
   describe "when the active pane item changes", ->

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -142,6 +142,7 @@ describe "TabBarView", ->
         onDidChangeIcon: ->
         onDidChangeModified: ->
         onDidSave: ->
+        onDidChangePath: ->
 
       warnings = []
       spyOn(console, "warn").andCallFake (message, object) ->
@@ -161,6 +162,9 @@ describe "TabBarView", ->
 
       expect(warnings[3].message).toContain("onDidSave")
       expect(warnings[3].object).toBe(badItem)
+
+      expect(warnings[4].message).toContain("onDidChangePath")
+      expect(warnings[4].object).toBe(badItem)
 
   describe "when the active pane item changes", ->
     it "highlights the tab for the new active pane item", ->


### PR DESCRIPTION
This should fix #189.

Tab-View currently listens to the title changed event and calls various methods to update its data/view.
The problem is that the path is never set after a rename or save-as operation so those methods use out of date data.
This PR should fix this issue by listening to path changed event instead and setting `@path` correctly.