### PR TITLE
(WIP) Style tab if pane has pending item

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -16,10 +16,10 @@ module.exports =
       type: 'integer'
       default: 120
       description: 'Threshold for switching to the next/previous tab when the `Tab Scrolling` config setting is enabled. Higher numbers mean that a longer scroll is needed to jump to the next/previous tab.'
-    usePreviewTabs:
-      type: 'boolean'
-      default: false
-      description: 'Tabs will only stay open if they\'re double-clicked or their contents is modified.'
+    # usePreviewTabs:
+    #   type: 'boolean'
+    #   default: false
+    #   description: 'Tabs will only stay open if they\'re double-clicked or their contents is modified.'
     enableVcsColoring:
       title: "Enable VCS Coloring"
       type: 'boolean'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -16,10 +16,6 @@ module.exports =
       type: 'integer'
       default: 120
       description: 'Threshold for switching to the next/previous tab when the `Tab Scrolling` config setting is enabled. Higher numbers mean that a longer scroll is needed to jump to the next/previous tab.'
-    # usePreviewTabs:
-    #   type: 'boolean'
-    #   default: false
-    #   description: 'Tabs will only stay open if they\'re double-clicked or their contents is modified.'
     enableVcsColoring:
       title: "Enable VCS Coloring"
       type: 'boolean'

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -70,6 +70,9 @@ class TabBarView extends HTMLElement
       @destroyPreviousPreviewTab()
       @updateActiveTab()
 
+    @subscriptions.add @pane.onDidConfirmPendingItem ({item}) =>
+      @tabForItem(item)?.clearPreview()
+
     @subscriptions.add atom.config.observe 'tabs.tabScrolling', => @updateTabScrolling()
     @subscriptions.add atom.config.observe 'tabs.tabScrollingThreshold', => @updateTabScrollingThreshold()
     @subscriptions.add atom.config.observe 'tabs.alwaysShowTabBar', => @updateTabBarVisibility()

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -8,8 +8,6 @@ class TabView extends HTMLElement
       @path = @item.getPath()
       @isPreviewTab = atom.workspace.getActivePane().isActiveItemPending()
 
-    atom.workspace.getActivePane().onDidConfirmPendingItem => @clearPreview()
-
     @classList.add('tab', 'sortable')
 
     @itemTitle = document.createElement('div')

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -6,7 +6,9 @@ class TabView extends HTMLElement
   initialize: (@item) ->
     if typeof @item.getPath is 'function'
       @path = @item.getPath()
-      @isPreviewTab = atom.config.get('tabs.usePreviewTabs')
+      @isPreviewTab = atom.workspace.getActivePane().isActiveItemPending()
+
+    atom.workspace.getActivePane().onDidConfirmPendingItem => @clearPreview()
 
     @classList.add('tab', 'sortable')
 

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -858,28 +858,10 @@ describe "TabBarView", ->
       it "adds tab with class 'temp'", ->
         editor1 = null
         waitsForPromise ->
-          atom.workspace.open('sample.txt').then (o) -> editor1 = o
+          atom.workspace.open('sample.txt', pending: true).then (o) -> editor1 = o
 
         runs ->
-          pane.activateItem(editor1)
-          expect($(tabBar).find('.tab .temp').length).toBe 1
-          expect($(tabBar).find('.tab:eq(0) .title')).toHaveClass 'temp'
-
-
-
-  describe "when usePreviewTabs is true in package settings", ->
-    beforeEach ->
-      atom.config.set("tabs.usePreviewTabs", true)
-      pane.destroyItems()
-
-    describe "when opening a new tab", ->
-      it "adds tab with class 'temp'", ->
-        editor1 = null
-        waitsForPromise ->
-          atom.workspace.open('sample.txt').then (o) -> editor1 = o
-
-        runs ->
-          pane.activateItem(editor1)
+          pane.activateItem(editor1, pending: true)
           expect($(tabBar).find('.tab .temp').length).toBe 1
           expect($(tabBar).find('.tab:eq(0) .title')).toHaveClass 'temp'
 
@@ -887,10 +869,10 @@ describe "TabBarView", ->
       it "removes the 'temp' class", ->
         editor1 = null
         waitsForPromise ->
-          atom.workspace.open('sample.txt').then (o) -> editor1 = o
+          atom.workspace.open('sample.txt', pending: true).then (o) -> editor1 = o
 
         runs ->
-          pane.activateItem(editor1)
+          pane.activateItem(editor1, pending: true)
           expect($(tabBar).find('.tab .temp').length).toBe 1
           atom.commands.dispatch(atom.views.getView(atom.workspace.getActivePane()), 'tabs:keep-preview-tab')
           expect($(tabBar).find('.tab .temp').length).toBe 0
@@ -901,12 +883,12 @@ describe "TabBarView", ->
         editor2 = null
 
         waitsForPromise ->
-          atom.workspace.open('sample.txt').then (o) ->
+          atom.workspace.open('sample.txt', pending: true).then (o) ->
             editor1 = o
-            pane.activateItem(editor1)
-            atom.workspace.open('sample2.txt').then (o) ->
+            pane.activateItem(editor1, pending: true)
+            atom.workspace.open('sample2.txt', pending: true).then (o) ->
               editor2 = o
-              pane.activateItem(editor2)
+              pane.activateItem(editor2, pending: true)
 
         runs ->
           expect(editor1.isDestroyed()).toBe true
@@ -933,9 +915,9 @@ describe "TabBarView", ->
 
       beforeEach ->
         waitsForPromise ->
-          atom.workspace.open('sample.txt').then (o) ->
+          atom.workspace.open('sample.txt', pending: true).then (o) ->
             editor2 = o
-            pane.activateItem(editor2)
+            pane.activateItem(editor2, pending: true)
 
         waitsForPromise ->
           atom.packages.activatePackage('settings-view').then ->
@@ -943,13 +925,12 @@ describe "TabBarView", ->
               settingsView = o
               pane.activateItem(settingsView)
 
+      it 'destroys existing temp tab', ->
+        expect(tabBar.tabForItem(editor2)).not.toExist()
+
       it 'creates a permanent tab', ->
         expect(tabBar.tabForItem(settingsView)).toExist()
         expect($(tabBar.tabForItem(settingsView)).find('.title')).not.toHaveClass 'temp'
-
-      it 'keeps an existing temp tab', ->
-        expect(tabBar.tabForItem(editor2)).toExist()
-        expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
 
     describe 'when editing a file', ->
       it 'makes the tab permanent', ->
@@ -977,8 +958,7 @@ describe "TabBarView", ->
           expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'
 
     describe 'when switching from a preview tab to a permanent tab', ->
-      it "keeps the preview tab open", ->
-        atom.config.set("tabs.usePreviewTabs", false)
+      it "keeps closes the preview tab", ->
         editor1 = null
         editor2 = null
 
@@ -987,19 +967,16 @@ describe "TabBarView", ->
             editor1 = o
             pane.activateItem(editor1)
 
-        runs ->
-          atom.config.set("tabs.usePreviewTabs", true)
-
         waitsForPromise ->
-          atom.workspace.open('sample2.txt').then (o) ->
+          atom.workspace.open('sample2.txt', pending: true).then (o) ->
             editor2 = o
-            pane.activateItem(editor2)
+            pane.activateItem(editor2, pending: true)
 
         runs ->
           pane.activateItem(editor1)
-          expect(pane.getItems().length).toBe 2
+          expect(pane.getItems().length).toBe 1
           expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'
-          expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
+          expect(tabBar.tabForItem(editor2)).not.toExist()
 
     describe "when splitting a preview tab", ->
       it "makes the tab permanent in the new pane", ->
@@ -1031,18 +1008,6 @@ describe "TabBarView", ->
 
           expect($(tabBar2.tabForItem(pane2.getActiveItem())).find('.title')).not.toHaveClass 'temp'
 
-    describe "when a non-text file is opened", ->
-      it "opens a preview tab", ->
-        imageView = null
-        waitsForPromise ->
-          atom.workspace.open('sample.png').then (o) ->
-            imageView = o
-            pane.activateItem(imageView)
-
-        runs ->
-          expect(tabBar.tabForItem(imageView)).toExist()
-          expect($(tabBar.tabForItem(imageView)).find('.title')).toHaveClass 'temp'
-
     describe "when double clicking a file in the tree view", ->
       it "makes the tab for that file permanent", ->
         editor1 = null
@@ -1059,10 +1024,10 @@ describe "TabBarView", ->
           workspaceElement.querySelector('.tree-view')
 
         waitsForPromise ->
-          atom.workspace.open('sample.js').then (o) -> editor1 = o
+          atom.workspace.open('sample.js', pending: true).then (o) -> editor1 = o
 
         runs ->
-          pane.activateItem(editor1)
+          pane.activateItem(editor1, pending: true)
 
           expect($(tabBar.tabForItem(editor1)).find('.title')).toHaveClass 'temp'
 

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -44,26 +44,26 @@ describe "Tabs package main", ->
       expect(workspaceElement.querySelectorAll('.pane').length).toBe 3
       expect(workspaceElement.querySelectorAll('.pane > .tab-bar').length).toBe 0
 
-    it "serializes preview tab state", ->
-      atom.config.set('tabs.usePreviewTabs', true)
-
-      waitsForPromise ->
-        atom.workspace.open('sample.txt')
-
-      runs ->
-        expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 1
-        expect(workspaceElement.querySelector('.tab.preview-tab .title')?.textContent).toBe 'sample.txt'
-
-        atom.packages.deactivatePackage('tabs')
-
-        expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 0
-
-      waitsForPromise ->
-        atom.packages.activatePackage('tabs')
-
-      runs ->
-        expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 1
-        expect(workspaceElement.querySelector('.tab.preview-tab .title')?.textContent).toBe 'sample.txt'
+    # it "serializes preview tab state", ->
+    #   atom.config.set('tabs.usePreviewTabs', true)
+    #
+    #   waitsForPromise ->
+    #     atom.workspace.open('sample.txt')
+    #
+    #   runs ->
+    #     expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 1
+    #     expect(workspaceElement.querySelector('.tab.preview-tab .title')?.textContent).toBe 'sample.txt'
+    #
+    #     atom.packages.deactivatePackage('tabs')
+    #
+    #     expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 0
+    #
+    #   waitsForPromise ->
+    #     atom.packages.activatePackage('tabs')
+    #
+    #   runs ->
+    #     expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 1
+    #     expect(workspaceElement.querySelector('.tab.preview-tab .title')?.textContent).toBe 'sample.txt'
 
 describe "TabBarView", ->
   [deserializerDisposable, item1, item2, editor1, pane, tabBar] = []
@@ -849,6 +849,23 @@ describe "TabBarView", ->
         pane.destroyItem(item2)
         expect(pane.getItems().length).toBe 1
         expect(tabBar).toHaveClass 'hidden'
+
+  describe "when tab is for a pending item", ->
+    beforeEach ->
+      pane.destroyItems()
+
+    describe "when opening a new tab", ->
+      it "adds tab with class 'temp'", ->
+        editor1 = null
+        waitsForPromise ->
+          atom.workspace.open('sample.txt').then (o) -> editor1 = o
+
+        runs ->
+          pane.activateItem(editor1)
+          expect($(tabBar).find('.tab .temp').length).toBe 1
+          expect($(tabBar).find('.tab:eq(0) .title')).toHaveClass 'temp'
+
+
 
   describe "when usePreviewTabs is true in package settings", ->
     beforeEach ->

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -44,26 +44,26 @@ describe "Tabs package main", ->
       expect(workspaceElement.querySelectorAll('.pane').length).toBe 3
       expect(workspaceElement.querySelectorAll('.pane > .tab-bar').length).toBe 0
 
-    # it "serializes preview tab state", ->
-    #   atom.config.set('tabs.usePreviewTabs', true)
-    #
-    #   waitsForPromise ->
-    #     atom.workspace.open('sample.txt')
-    #
-    #   runs ->
-    #     expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 1
-    #     expect(workspaceElement.querySelector('.tab.preview-tab .title')?.textContent).toBe 'sample.txt'
-    #
-    #     atom.packages.deactivatePackage('tabs')
-    #
-    #     expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 0
-    #
-    #   waitsForPromise ->
-    #     atom.packages.activatePackage('tabs')
-    #
-    #   runs ->
-    #     expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 1
-    #     expect(workspaceElement.querySelector('.tab.preview-tab .title')?.textContent).toBe 'sample.txt'
+    it "serializes preview tab state", ->
+      atom.config.set('tabs.usePreviewTabs', true)
+
+      waitsForPromise ->
+        atom.workspace.open('sample.txt', pending: true)
+
+      runs ->
+        expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 1
+        expect(workspaceElement.querySelector('.tab.preview-tab .title')?.textContent).toBe 'sample.txt'
+
+        atom.packages.deactivatePackage('tabs')
+
+        expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 0
+
+      waitsForPromise ->
+        atom.packages.activatePackage('tabs')
+
+      runs ->
+        expect(workspaceElement.querySelectorAll('.tab.preview-tab .title').length).toBe 1
+        expect(workspaceElement.querySelector('.tab.preview-tab .title')?.textContent).toBe 'sample.txt'
 
 describe "TabBarView", ->
   [deserializerDisposable, item1, item2, editor1, pane, tabBar] = []


### PR DESCRIPTION
Work in progress, just starting a conversation here.

See corresponding pull requests for core and tree-view packages:
- [atom core #10171](https://github.com/atom/atom/pull/10171)
- [tree-view #681](https://github.com/atom/tree-view/pull/681)

Disabled Preview Tabs setting. Still need to clean up code and remove what's unnecessary as well as write tests.