### PR TITLE
Style tab for pending item

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -48,4 +48,4 @@ module.exports =
 
   serialize: ->
     @tabBarViews.map (tabBarView) ->
-      previewTabURI: tabBarView.getPreviewTabURI()
+      pendingTabURI: tabBarView.getPendingTabURI()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -16,10 +16,6 @@ module.exports =
       type: 'integer'
       default: 120
       description: 'Threshold for switching to the next/previous tab when the `Tab Scrolling` config setting is enabled. Higher numbers mean that a longer scroll is needed to jump to the next/previous tab.'
-    usePreviewTabs:
-      type: 'boolean'
-      default: false
-      description: 'Tabs will only stay open if they\'re double-clicked or their contents is modified.'
     enableVcsColoring:
       title: "Enable VCS Coloring"
       type: 'boolean'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -23,7 +23,6 @@ module.exports =
       description: 'Color file names in tabs based on VCS status, similar to how file names are colored in the tree view.'
 
   activate: (state) ->
-    state = [] unless Array.isArray(state)
     @tabBarViews = []
 
     TabBarView = require './tab-bar-view'
@@ -31,7 +30,7 @@ module.exports =
 
     @paneSubscription = atom.workspace.observePanes (pane) =>
       tabBarView = new TabBarView
-      tabBarView.initialize(pane, state.shift())
+      tabBarView.initialize(pane)
 
       paneElement = atom.views.getView(pane)
       paneElement.insertBefore(tabBarView, paneElement.firstChild)
@@ -39,13 +38,7 @@ module.exports =
       @tabBarViews.push(tabBarView)
       pane.onDidDestroy => _.remove(@tabBarViews, tabBarView)
 
-    state = [] # Reset state so it only affects the initial panes observed
-
   deactivate: ->
     @paneSubscription.dispose()
     tabBarView.remove() for tabBarView in @tabBarViews
     return
-
-  serialize: ->
-    @tabBarViews.map (tabBarView) ->
-      pendingTabURI: tabBarView.getPendingTabURI()

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -374,7 +374,7 @@ class TabBarView extends HTMLElement
       event.preventDefault()
     else if event.which is 1 and not event.target.classList.contains('close-icon')
       @pane.setActiveItem(tab.item)
-      tab.item.confirmPendingState()
+      tab.item.confirmPendingState?()
       setImmediate => @pane.activate()
     else if event.which is 2
       @pane.destroyItem(tab.item)

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -373,7 +373,8 @@ class TabBarView extends HTMLElement
       tab.classList.add('right-clicked')
       event.preventDefault()
     else if event.which is 1 and not event.target.classList.contains('close-icon')
-      @pane.activateItem(tab.item)
+      @pane.setActiveItem(tab.item)
+      tab.item.confirmPendingState()
       setImmediate => @pane.activate()
     else if event.which is 2
       @pane.destroyItem(tab.item)

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -335,14 +335,16 @@ class TabBarView extends HTMLElement
       event.preventDefault()
     else if event.which is 1 and not event.target.classList.contains('close-icon')
       @pane.activateItem(tab.item)
-      tab.item.terminatePendingState?()
       setImmediate => @pane.activate() unless @pane.isDestroyed()
     else if event.which is 2
       @pane.destroyItem(tab.item)
       event.preventDefault()
 
   onDoubleClick: (event) ->
-    if event.target is this
+    if tab = closest(event.target, '.tab')
+      tab.item.terminatePendingState?()
+
+    else if event.target is this
       atom.commands.dispatch(this, 'application:new-file')
       event.preventDefault()
 

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -348,7 +348,7 @@ class TabBarView extends HTMLElement
     else if event.which is 1 and not event.target.classList.contains('close-icon')
       @pane.activateItem(tab.item)
       tab.item.terminatePendingState?()
-      setImmediate => @pane.activate()
+      setImmediate => @pane.activate() unless @pane.isDestroyed()
     else if event.which is 2
       @pane.destroyItem(tab.item)
       event.preventDefault()

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -373,7 +373,7 @@ class TabBarView extends HTMLElement
       tab.classList.add('right-clicked')
       event.preventDefault()
     else if event.which is 1 and not event.target.classList.contains('close-icon')
-      @pane.setActiveItem(tab.item)
+      @pane.activateItem(tab.item)
       tab.item.confirmPendingState?()
       setImmediate => @pane.activate()
     else if event.which is 2

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -67,7 +67,6 @@ class TabBarView extends HTMLElement
       @removeTabForItem(item)
 
     @subscriptions.add @pane.onDidChangeActiveItem (item) =>
-      @destroyPreviousPendingTab()
       @updateActiveTab()
 
     @subscriptions.add atom.config.observe 'tabs.tabScrolling', => @updateTabScrolling()
@@ -91,21 +90,10 @@ class TabBarView extends HTMLElement
     tab.terminatePendingState?() for tab in @getTabs()
     return
 
-  storePendingTabToDestroy: ->
-    for tab in @getTabs() when tab.isPendingTab
-      @pendingTabToDestroy = tab
-    return
-
-  destroyPreviousPendingTab: ->
-    if @pendingTabToDestroy?.isPendingTab
-      @pane.destroyItem(@pendingTabToDestroy.item)
-    @pendingTabToDestroy = null
-
   addTabForItem: (item, index) ->
     tabView = new TabView()
     tabView.initialize(item)
     tabView.terminatePendingState() if @isItemMovingBetweenPanes
-    @storePendingTabToDestroy() if tabView.isPendingTab
     @insertTabAtIndex(tabView, index)
 
   moveItemTabToIndex: (item, index) ->

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -374,7 +374,7 @@ class TabBarView extends HTMLElement
       event.preventDefault()
     else if event.which is 1 and not event.target.classList.contains('close-icon')
       @pane.activateItem(tab.item)
-      tab.item.confirmPendingState?()
+      tab.item.terminatePendingState?()
       setImmediate => @pane.activate()
     else if event.which is 2
       @pane.destroyItem(tab.item)

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -18,7 +18,7 @@ class TabBarView extends HTMLElement
     @subscriptions = new CompositeDisposable
 
     @subscriptions.add atom.commands.add atom.views.getView(@pane),
-      'tabs:keep-preview-tab': => @clearPreviewTabs()
+      'tabs:keep-preview-tab': => @terminatePendingStates()
       'tabs:close-tab': => @closeTab(@getActiveTab())
       'tabs:close-other-tabs': => @closeOtherTabs(@getActiveTab())
       'tabs:close-tabs-to-right': => @closeTabsToRight(@getActiveTab())
@@ -117,6 +117,10 @@ class TabBarView extends HTMLElement
 
   clearPreviewTabs: ->
     tab.clearPreview() for tab in @getTabs()
+    return
+
+  terminatePendingStates: ->
+    tab.terminatePendingState() for tab in @getTabs()
     return
 
   storePreviewTabToDestroy: ->

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -83,10 +83,11 @@ class TabBarView extends HTMLElement
     @addEventListener "dblclick", @onDoubleClick
     @addEventListener "click", @onClick
 
-    ipcRenderer.on('tab:dropped', @onDropOnOtherWindow.bind(this))
+    @onDropOnOtherWindow = @onDropOnOtherWindow.bind(this)
+    ipcRenderer.on('tab:dropped',  @onDropOnOtherWindow)
 
   unsubscribe: ->
-    ipcRenderer.removeListener('tab:dropped', @onDropOnOtherWindow.bind(this))
+    ipcRenderer.removeListener('tab:dropped', @onDropOnOtherWindow)
     @subscriptions.dispose()
 
   handleTreeViewEvents: ->

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -6,7 +6,7 @@ class TabView extends HTMLElement
   initialize: (@item) ->
     if typeof @item.getPath is 'function'
       @path = @item.getPath()
-      @isPreviewTab = @item.isPending?()
+      @isPendingTab = @item.isPending?()
 
     @classList.add('tab', 'sortable')
 
@@ -27,10 +27,10 @@ class TabView extends HTMLElement
     @updateModifiedStatus()
     @setupTooltip()
 
-    if @isPreviewTab
+    if @isPendingTab
       @itemTitle.classList.add('temp')
-      @classList.add('preview-tab')
-      @addEventListener 'dblclick', => @clearPreview()
+      @classList.add('pending-tab')
+      @addEventListener 'dblclick', => @clearPending()
 
   handleEvents: ->
     titleChangedHandler = =>
@@ -39,7 +39,7 @@ class TabView extends HTMLElement
       @updateTooltip()
 
     if typeof @item.onDidTerminatePendingState is 'function'
-      onDidTerminatePendingStateDisposable = @item.onDidTerminatePendingState => @clearPreview()
+      onDidTerminatePendingStateDisposable = @item.onDidTerminatePendingState => @clearPending()
       if Disposable.isDisposable(onDidTerminatePendingStateDisposable)
         @subscriptions.add(onDidTerminatePendingStateDisposable)
       else
@@ -90,7 +90,7 @@ class TabView extends HTMLElement
 
     if typeof @item.onDidSave is 'function'
       onDidSaveDisposable = @item.onDidSave (event) =>
-        @clearPreview()
+        @clearPending()
         if event.path isnt @path
           @path = event.path
           @setupVcsStatus() if atom.config.get 'tabs.enableVcsColoring'
@@ -193,10 +193,10 @@ class TabView extends HTMLElement
   terminatePendingState: ->
     @item.terminatePendingState?()
 
-  clearPreview: ->
-    @isPreviewTab = false
+  clearPending: ->
+    @isPendingTab = false
     @itemTitle.classList.remove('temp')
-    @classList.remove('preview-tab')
+    @classList.remove('pending-tab')
 
   updateIconVisibility: ->
     if atom.config.get 'tabs.showIcons'
@@ -206,7 +206,7 @@ class TabView extends HTMLElement
 
   updateModifiedStatus: ->
     if @item.isModified?()
-      @clearPreview()
+      @clearPending()
       @classList.add('modified') unless @isModified
       @isModified = true
     else

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -38,12 +38,12 @@ class TabView extends HTMLElement
       @updateTitle()
       @updateTooltip()
 
-    if typeof @item.onDidConfirmPendingState is 'function'
-      onDidConfirmPendingStateDisposable = @item.onDidConfirmPendingState => @clearPreview()
-      if Disposable.isDisposable(onDidConfirmPendingStateDisposable)
-        @subscriptions.add(onDidConfirmPendingStateDisposable)
+    if typeof @item.onDidTerminatePendingState is 'function'
+      onDidTerminatePendingStateDisposable = @item.onDidTerminatePendingState => @clearPreview()
+      if Disposable.isDisposable(onDidTerminatePendingStateDisposable)
+        @subscriptions.add(onDidTerminatePendingStateDisposable)
       else
-        console.warn "::onDidConfirmPendingState does not return a valid Disposable!", @item
+        console.warn "::onDidTerminatePendingState does not return a valid Disposable!", @item
 
     if typeof @item.onDidChangeTitle is 'function'
       onDidChangeTitleDisposable = @item.onDidChangeTitle(titleChangedHandler)

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -30,7 +30,6 @@ class TabView extends HTMLElement
     if @isPendingTab
       @itemTitle.classList.add('temp')
       @classList.add('pending-tab')
-      @addEventListener 'dblclick', => @clearPending()
 
   handleEvents: ->
     titleChangedHandler = =>
@@ -90,7 +89,7 @@ class TabView extends HTMLElement
 
     if typeof @item.onDidSave is 'function'
       onDidSaveDisposable = @item.onDidSave (event) =>
-        @clearPending()
+        @terminatePendingState()
         if event.path isnt @path
           @path = event.path
           @setupVcsStatus() if atom.config.get 'tabs.enableVcsColoring'
@@ -206,7 +205,6 @@ class TabView extends HTMLElement
 
   updateModifiedStatus: ->
     if @item.isModified?()
-      @clearPending()
       @classList.add('modified') unless @isModified
       @isModified = true
     else

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -190,6 +190,9 @@ class TabView extends HTMLElement
   getTabs: ->
     @parentElement?.querySelectorAll('.tab') ? []
 
+  terminatePendingState: ->
+    @item.terminatePendingState?()
+
   clearPreview: ->
     @isPreviewTab = false
     @itemTitle.classList.remove('temp')

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -6,7 +6,7 @@ class TabView extends HTMLElement
   initialize: (@item) ->
     if typeof @item.getPath is 'function'
       @path = @item.getPath()
-      @isPreviewTab = atom.config.get('tabs.usePreviewTabs')
+      @isPreviewTab = @item.isPending()
 
     @classList.add('tab', 'sortable')
 
@@ -37,6 +37,13 @@ class TabView extends HTMLElement
       @updateDataAttributes()
       @updateTitle()
       @updateTooltip()
+
+    if typeof @item.onDidConfirmPendingState is 'function'
+      onDidConfirmPendingStateDisposable = @item.onDidConfirmPendingState => @clearPreview()
+      if Disposable.isDisposable(onDidConfirmPendingStateDisposable)
+        @subscriptions.add(onDidConfirmPendingStateDisposable)
+      else
+        console.warn "::onDidConfirmPendingState does not return a valid Disposable!", @item
 
     if typeof @item.onDidChangeTitle is 'function'
       onDidChangeTitleDisposable = @item.onDidChangeTitle(titleChangedHandler)

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -6,7 +6,7 @@ class TabView extends HTMLElement
   initialize: (@item) ->
     if typeof @item.getPath is 'function'
       @path = @item.getPath()
-      @isPreviewTab = @item.isPending()
+      @isPreviewTab = @item.isPending?()
 
     @classList.add('tab', 'sortable')
 

--- a/menus/tabs.cson
+++ b/menus/tabs.cson
@@ -22,8 +22,8 @@ menu: [
     {label: 'Split Left', command: 'tabs:split-left'}
     {label: 'Split Right', command: 'tabs:split-right'}
   ]
-  '.tab.preview-tab': [
-    {label: 'Keep Preview Tab', command: 'tabs:keep-preview-tab'}
+  '.tab.pending-tab': [
+    {label: 'Keep Pending Tab', command: 'tabs:keep-pending-tab'}
   ]
   '.tab-bar': [
     {label: 'Reopen Closed Tab', command: 'pane:reopen-closed-item'}

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -880,9 +880,8 @@ describe "TabBarView", ->
           waitsForPromise ->
             atom.workspace.open('sample.txt', pending: true).then (o) -> editor2 = o
 
-          waitsFor (done) ->
+          runs ->
             pane.activateItem(editor2)
-            pane.onDidActivate(done)
             expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
             triggerMouseEvent('mousedown', tabBar.tabForItem(editor2), which: 1)
             expect($(tabBar.tabForItem(editor2)).find('.title')).not.toHaveClass 'temp'

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -1000,18 +1000,6 @@ describe "TabBarView", ->
 
           expect($(tabBar2.tabForItem(pane2.getActiveItem())).find('.title')).not.toHaveClass 'temp'
 
-    describe "when a non-text file is opened", ->
-      it "opens a permanent tab", ->
-        imageView = null
-        waitsForPromise ->
-          atom.workspace.open('sample.png').then (o) ->
-            imageView = o
-            pane.activateItem(imageView)
-
-        runs ->
-          expect(tabBar.tabForItem(imageView)).toExist()
-          expect($(tabBar.tabForItem(imageView)).find('.title')).not.toHaveClass 'temp'
-
     describe "when double clicking a file in the tree view", ->
       it "makes the tab for that file permanent", ->
         editor1 = null

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -845,17 +845,17 @@ describe "TabBarView", ->
             expect($(tabBar).find('.tab .temp').length).toBe 1
             expect($(tabBar).find('.tab:eq(0) .title')).toHaveClass 'temp'
 
-      describe "when tabs:keep-preview-tab is trigger on the pane", ->
-        it "removes the 'temp' class", ->
+      describe "when tabs:keep-preview-tab is triggered on the pane", ->
+        it "terminates pending state on the tab's item", ->
           editor1 = null
           waitsForPromise ->
             atom.workspace.open('sample.txt', pending: true).then (o) -> editor1 = o
 
           runs ->
             pane.activateItem(editor1)
-            expect($(tabBar).find('.tab .temp').length).toBe 1
+            expect(editor1.isPending()).toBe true
             atom.commands.dispatch(atom.views.getView(atom.workspace.getActivePane()), 'tabs:keep-preview-tab')
-            expect($(tabBar).find('.tab .temp').length).toBe 0
+            expect(editor1.isPending()).toBe false
 
       describe "when there is a temp tab already", ->
         it "it will replace an existing temporary tab", ->

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -845,7 +845,7 @@ describe "TabBarView", ->
             expect($(tabBar).find('.tab .temp').length).toBe 1
             expect($(tabBar).find('.tab:eq(0) .title')).toHaveClass 'temp'
 
-      describe "when tabs:keep-preview-tab is triggered on the pane", ->
+      describe "when tabs:keep-pending-tab is triggered on the pane", ->
         it "terminates pending state on the tab's item", ->
           editor1 = null
           waitsForPromise ->
@@ -854,7 +854,7 @@ describe "TabBarView", ->
           runs ->
             pane.activateItem(editor1)
             expect(editor1.isPending()).toBe true
-            atom.commands.dispatch(atom.views.getView(atom.workspace.getActivePane()), 'tabs:keep-preview-tab')
+            atom.commands.dispatch(atom.views.getView(atom.workspace.getActivePane()), 'tabs:keep-pending-tab')
             expect(editor1.isPending()).toBe false
 
       describe "when there is a temp tab already", ->
@@ -933,8 +933,8 @@ describe "TabBarView", ->
           runs ->
             expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'
 
-      describe 'when switching from a preview tab to a permanent tab', ->
-        it "closes the preview tab", ->
+      describe 'when switching from a pending tab to a permanent tab', ->
+        it "closes the pending tab", ->
           editor1 = null
           editor2 = null
 
@@ -952,7 +952,7 @@ describe "TabBarView", ->
             expect(pane.getItems()).toEqual [editor1]
             expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'
 
-      describe "when splitting a preview tab", ->
+      describe "when splitting a pending tab", ->
         it "makes the tab permanent in the new pane", ->
           editor1 = null
           waitsForPromise ->
@@ -966,7 +966,7 @@ describe "TabBarView", ->
 
             expect($(tabBar2.tabForItem(pane2.getActiveItem())).find('.title')).not.toHaveClass 'temp'
 
-      describe "when dragging a preview tab to a different pane", ->
+      describe "when dragging a pending tab to a different pane", ->
         it "makes the tab permanent in the other pane", ->
           editor1 = null
           waitsForPromise ->

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -1039,8 +1039,8 @@ describe "TabBarView", ->
           fileNode.dispatchEvent(new MouseEvent('click', detail: 2, bubbles: true, cancelable: true))
           fileNode.dispatchEvent(new MouseEvent('dblclick', detail: 2, bubbles: true, cancelable: true))
 
-          waits(1) # wait for click handlers to get invoked
           expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'
+          waits(10) # async nature causes uncaught exceptions, so wait a little bit before we cleanup
 
   describe "integration with version control systems", ->
     [repository, tab, tab1] = []

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -873,7 +873,7 @@ describe "TabBarView", ->
             expect(tabBar.tabForItem(editor1)).not.toExist()
             expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
 
-        it "makes the tab permanent when clicking the tab", ->
+        it "makes the tab permanent when double-clicking the tab", ->
           editor2 = null
 
           waitsForPromise ->
@@ -882,7 +882,7 @@ describe "TabBarView", ->
           runs ->
             pane.activateItem(editor2)
             expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
-            triggerMouseEvent('mousedown', tabBar.tabForItem(editor2), which: 1)
+            triggerMouseEvent('dblclick', tabBar.tabForItem(editor2), which: 1)
             expect($(tabBar.tabForItem(editor2)).find('.title')).not.toHaveClass 'temp'
 
       describe "when editing a file in pending state", ->

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -892,18 +892,18 @@ describe "TabBarView", ->
           expect(tabBar.tabForItem(editor1)).not.toExist()
           expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
 
-      it 'makes the tab permanent when double clicking the tab', ->
+      it 'makes the tab permanent when clicking the tab', ->
         editor2 = null
 
         waitsForPromise ->
-          atom.workspace.open('sample.txt').then (o) -> editor2 = o
+          atom.workspace.open('sample.txt', pending: true).then (o) -> editor2 = o
 
         runs ->
           pane.activateItem(editor2)
-          dbclickEvt = document.createEvent 'MouseEvents'
-          dbclickEvt.initEvent 'dblclick'
-          tabBar.tabForItem(editor2).dispatchEvent dbclickEvt
+          expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
+          triggerMouseEvent('mousedown', tabBar.tabForItem(editor2), which: 1)
           expect($(tabBar.tabForItem(editor2)).find('.title')).not.toHaveClass 'temp'
+          waits 0 # To prevent uncaught error "Pane has been destroyed"
 
     describe 'when opening views that do not have file paths', ->
       editor2 = null
@@ -911,21 +911,20 @@ describe "TabBarView", ->
 
       beforeEach ->
         waitsForPromise ->
+          atom.workspace.open('sample.txt', pending: true).then (o) ->
+            editor2 = o
+
+        waitsForPromise ->
           atom.packages.activatePackage('settings-view').then ->
             atom.workspace.open('atom://config').then (o) ->
               settingsView = o
-
-        waitsForPromise ->
-          atom.workspace.open('sample.txt', pending: true).then (o) ->
-            editor2 = o
 
       it 'creates a permanent tab', ->
         expect(tabBar.tabForItem(settingsView)).toExist()
         expect($(tabBar.tabForItem(settingsView)).find('.title')).not.toHaveClass 'temp'
 
-      it 'keeps an existing temp tab', ->
-        expect(tabBar.tabForItem(editor2)).toExist()
-        expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
+      it 'destroys an existing temp tab', ->
+        expect(tabBar.tabForItem(editor2)).not.toExist()
 
     describe 'when editing a file', ->
       it 'makes the tab permanent', ->

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -873,7 +873,7 @@ describe "TabBarView", ->
             expect(tabBar.tabForItem(editor1)).not.toExist()
             expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
 
-        it 'makes the tab permanent when clicking the tab', ->
+        it "makes the tab permanent when clicking the tab", ->
           editor2 = null
 
           waitsForPromise ->
@@ -885,8 +885,8 @@ describe "TabBarView", ->
             triggerMouseEvent('mousedown', tabBar.tabForItem(editor2), which: 1)
             expect($(tabBar.tabForItem(editor2)).find('.title')).not.toHaveClass 'temp'
 
-      describe 'when editing a file in pending state', ->
-        it 'makes the item and tab permanent', ->
+      describe "when editing a file in pending state", ->
+        it "makes the item and tab permanent", ->
           editor1 = null
           waitsForPromise ->
             atom.workspace.open('sample.txt', pending: true).then (o) ->
@@ -898,8 +898,8 @@ describe "TabBarView", ->
           runs ->
             expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'
 
-      describe 'when saving a file', ->
-        it 'makes the tab permanent', ->
+      describe "when saving a file", ->
+        it "makes the tab permanent", ->
           editor1 = null
           waitsForPromise ->
             atom.workspace.open(path.join(temp.mkdirSync('tabs-'), 'sample.txt'), pending: true).then (o) ->
@@ -910,7 +910,7 @@ describe "TabBarView", ->
           runs ->
             expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'
 
-      describe 'when switching from a pending tab to a permanent tab', ->
+      describe "when switching from a pending tab to a permanent tab", ->
         it "keeps the pending tab open", ->
           editor1 = null
           editor2 = null

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -880,12 +880,12 @@ describe "TabBarView", ->
           waitsForPromise ->
             atom.workspace.open('sample.txt', pending: true).then (o) -> editor2 = o
 
-          runs ->
+          waitsFor (done) ->
             pane.activateItem(editor2)
+            pane.onDidActivate(done)
             expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
             triggerMouseEvent('mousedown', tabBar.tabForItem(editor2), which: 1)
             expect($(tabBar.tabForItem(editor2)).find('.title')).not.toHaveClass 'temp'
-            waits 0 # To prevent uncaught error "Pane has been destroyed"
 
       describe 'when opening views that do not have file paths', ->
         editor2 = null

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -870,7 +870,6 @@ describe "TabBarView", ->
 
           runs ->
             expect(editor1.isDestroyed()).toBe true
-            expect(editor2.isDestroyed()).toBe false
             expect(tabBar.tabForItem(editor1)).not.toExist()
             expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
 
@@ -886,24 +885,11 @@ describe "TabBarView", ->
             triggerMouseEvent('mousedown', tabBar.tabForItem(editor2), which: 1)
             expect($(tabBar.tabForItem(editor2)).find('.title')).not.toHaveClass 'temp'
 
-      describe 'when opening views that do not have file paths', ->
-
-        it 'creates a permanent tab', ->
-          settingsView = null
-          waitsForPromise ->
-            atom.packages.activatePackage('settings-view').then ->
-              atom.workspace.open('atom://config').then (o) ->
-                settingsView = o
-
-          runs ->
-            expect(tabBar.tabForItem(settingsView)).toExist()
-            expect($(tabBar.tabForItem(settingsView)).find('.title')).not.toHaveClass 'temp'
-
-      describe 'when editing a file', ->
-        it 'makes the tab permanent', ->
+      describe 'when editing a file in pending state', ->
+        it 'makes the item and tab permanent', ->
           editor1 = null
           waitsForPromise ->
-            atom.workspace.open('sample.txt').then (o) ->
+            atom.workspace.open('sample.txt', pending: true).then (o) ->
               editor1 = o
               pane.activateItem(editor1)
               editor1.insertText('x')
@@ -916,7 +902,7 @@ describe "TabBarView", ->
         it 'makes the tab permanent', ->
           editor1 = null
           waitsForPromise ->
-            atom.workspace.open(path.join(temp.mkdirSync('tabs-'), 'sample.txt')).then (o) ->
+            atom.workspace.open(path.join(temp.mkdirSync('tabs-'), 'sample.txt'), pending: true).then (o) ->
               editor1 = o
               pane.activateItem(editor1)
               editor1.save()
@@ -966,7 +952,7 @@ describe "TabBarView", ->
         it "makes the tab permanent in the other pane", ->
           editor1 = null
           waitsForPromise ->
-            atom.workspace.open('sample.txt').then (o) -> editor1 = o
+            atom.workspace.open('sample.txt', pending: true).then (o) -> editor1 = o
 
           runs ->
             pane.activateItem(editor1)

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -982,35 +982,6 @@ describe "TabBarView", ->
 
             expect($(tabBar2.tabForItem(pane2.getActiveItem())).find('.title')).not.toHaveClass 'temp'
 
-      describe "when double clicking a file in the tree view", ->
-        it "makes the tab for that file permanent", ->
-          editor1 = null
-          workspaceElement = atom.views.getView(atom.workspace)
-          jasmine.attachToDOM(workspaceElement)
-
-          waitsForPromise ->
-            atom.packages.activatePackage('tree-view')
-
-          runs ->
-            atom.commands.dispatch(workspaceElement, 'tree-view:show')
-
-          waitsFor ->
-            workspaceElement.querySelector('.tree-view')
-
-          waitsForPromise ->
-            atom.workspace.open('sample.js', pending: true).then (o) -> editor1 = o
-
-          runs ->
-            expect($(tabBar.tabForItem(editor1)).find('.title')).toHaveClass 'temp'
-
-            fileNode = workspaceElement.querySelector(".tree-view [data-path=\"#{path.join(__dirname, 'fixtures', 'sample.js')}\"]")
-            fileNode.dispatchEvent(new MouseEvent('click', detail: 1, bubbles: true, cancelable: true))
-            fileNode.dispatchEvent(new MouseEvent('click', detail: 2, bubbles: true, cancelable: true))
-            fileNode.dispatchEvent(new MouseEvent('dblclick', detail: 2, bubbles: true, cancelable: true))
-
-            expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'
-            waits(10) # async nature causes uncaught exceptions, so wait a little bit before we cleanup
-
   describe "integration with version control systems", ->
     [repository, tab, tab1] = []
 


### PR DESCRIPTION
Single-clicking opens a file in pending state and double-clicking opens a file regularly (in a non-pending state).

See corresponding changes in [atom/atom/pull/10178](https://github.com/atom/atom/pull/10178)
Addresses atom/atom/issues/9165