### PR TITLE
Drag and drop layout management

### DIFF
--- a/lib/layout.coffee
+++ b/lib/layout.coffee
@@ -10,6 +10,8 @@ module.exports =
   deactivate: ->
     @view.parentElement?.removeChild @view
 
+  test: {}
+
   drag: (e) ->
     @lastCoords = e
     pane = @getPaneAt e
@@ -44,10 +46,10 @@ module.exports =
     closest document.elementFromPoint(clientX, clientY), selector
 
   getItemViewAt: (coords) ->
-    @getElement coords, '.item-views'
+    @test.itemView or @getElement coords, '.item-views'
 
   getPaneAt: (coords) ->
-    @getElement(@lastCoords, 'atom-pane')?.getModel()
+    @test.pane or @getElement(@lastCoords, 'atom-pane')?.getModel()
 
   paneForTab: (tab) ->
     tab.parentElement.pane
@@ -88,7 +90,7 @@ module.exports =
 
   updateView: (pane, coords) ->
     @view.classList.add 'visible'
-    rect = pane.getBoundingClientRect()
+    rect = @test.rect or pane.getBoundingClientRect()
     split = if coords then @splitType @normalizeCoords rect, coords
     @updateViewBounds @innerBounds rect, @boundsForSplit split
     split

--- a/lib/layout.coffee
+++ b/lib/layout.coffee
@@ -4,8 +4,8 @@ module.exports =
 
   activate: ->
     @view = document.createElement 'div'
-    @view.classList.add 'layout-overlay'
     document.body.appendChild @view
+    @view.classList.add 'tabs-layout-overlay'
 
   deactivate: ->
     @view.parentElement?.removeChild @view

--- a/lib/layout.coffee
+++ b/lib/layout.coffee
@@ -1,0 +1,97 @@
+{closest, indexOf, matches} = require './html-helpers'
+
+module.exports =
+
+  activate: ->
+    @view = document.createElement 'div'
+    @view.classList.add 'layout-overlay'
+    document.body.appendChild @view
+
+  deactivate: ->
+    @view.parentElement?.removeChild @view
+
+  drag: (e) ->
+    @lastCoords = e
+    pane = @getPaneAt e
+    itemView = @getItemViewAt e
+    if pane? and itemView?
+      coords = if not (@isOnlyTabInPane(pane, e.target) or pane.getItems().length is 0)
+        [e.clientX, e.clientY]
+      @lastSplit = @updateView itemView, coords
+    else
+      @disableView()
+
+  end: (e) ->
+    @disableView()
+    return unless @getItemViewAt @lastCoords
+    target = @getPaneAt @lastCoords
+    return unless target?
+    toPane = switch @lastSplit
+      when 'left'  then target.splitLeft()
+      when 'right' then target.splitRight()
+      when 'up'    then target.splitUp()
+      when 'down'  then target.splitDown()
+    tab = e.target
+    toPane ?= target
+    fromPane = @paneForTab tab
+    return if toPane is fromPane
+    item = @itemForTab tab
+    fromPane.moveItemToPane item, toPane
+    toPane.activateItem item
+    toPane.activate()
+
+  getElement: ({clientX, clientY}, selector = '*') ->
+    closest document.elementFromPoint(clientX, clientY), selector
+
+  getItemViewAt: (coords) ->
+    @getElement coords, '.item-views'
+
+  getPaneAt: (coords) ->
+    @getElement(@lastCoords, 'atom-pane')?.getModel()
+
+  paneForTab: (tab) ->
+    tab.parentElement.pane
+
+  itemForTab: (tab) ->
+    @paneForTab(tab).getItems()[indexOf(tab)]
+
+  isOnlyTabInPane: (pane, tab) ->
+    pane.getItems().length is 1 and pane is @paneForTab tab
+
+  normalizeCoords: ({left, top, width, height}, [x, y]) ->
+    [(x-left)/width, (y-top)/height]
+
+  splitType: ([x, y]) ->
+    if      x < 1/3 then 'left'
+    else if x > 2/3 then 'right'
+    else if y < 1/3 then 'up'
+    else if y > 2/3 then 'down'
+
+  boundsForSplit: (split) ->
+    [x, y, w, h] = switch split
+      when 'left'   then [0,   0,   0.5, 1  ]
+      when 'right'  then [0.5, 0,   0.5, 1  ]
+      when 'up'     then [0,   0,   1,   0.5]
+      when 'down'   then [0,   0.5, 1,   0.5]
+      else               [0,   0,   1,   1  ]
+
+  innerBounds: ({left, top, width, height}, [x, y, w, h]) ->
+    left += x*width; top += y*height
+    width *= w; height *= h
+    {left, top, width, height}
+
+  updateViewBounds: ({left, top, width, height}) ->
+    @view.style.left = "#{left}px"
+    @view.style.top = "#{top}px"
+    @view.style.width = "#{width}px"
+    @view.style.height = "#{height}px"
+
+  updateView: (pane, coords) ->
+    @view.classList.add 'visible'
+    rect = pane.getBoundingClientRect()
+    split = if coords then @splitType @normalizeCoords rect, coords
+    @updateViewBounds @innerBounds rect, @boundsForSplit split
+    split
+
+  disableView: ->
+    @view.classList.remove 'visible'

--- a/lib/layout.coffee
+++ b/lib/layout.coffee
@@ -4,7 +4,7 @@ module.exports =
 
   activate: ->
     @view = document.createElement 'div'
-    document.body.appendChild @view
+    atom.views.getView(atom.workspace).appendChild @view
     @view.classList.add 'tabs-layout-overlay'
 
   deactivate: ->

--- a/lib/layout.coffee
+++ b/lib/layout.coffee
@@ -78,8 +78,10 @@ module.exports =
       else               [0,   0,   1,   1  ]
 
   innerBounds: ({left, top, width, height}, [x, y, w, h]) ->
-    left += x*width; top += y*height
-    width *= w; height *= h
+    left += x*width
+    top  += y*height
+    width  *= w
+    height *= h
     {left, top, width, height}
 
   updateViewBounds: ({left, top, width, height}) ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,7 +1,9 @@
 FileIcons = require './file-icons'
+layout = require './layout'
 
 module.exports =
   activate: (state) ->
+    layout.activate()
     @tabBarViews = []
 
     TabBarView = require './tab-bar-view'
@@ -27,6 +29,7 @@ module.exports =
       pane.onDidDestroy => _.remove(@tabBarViews, tabBarView)
 
   deactivate: ->
+    layout.deactivate()
     @paneSubscription.dispose()
     @fileIconsDisposable?.dispose()
     tabBarView.remove() for tabBarView in @tabBarViews

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -2,6 +2,8 @@ path = require 'path'
 {Disposable, CompositeDisposable} = require 'atom'
 FileIcons = require './file-icons'
 
+layout = require './layout'
+
 module.exports =
 class TabView extends HTMLElement
   initialize: (@item, @pane) ->
@@ -32,6 +34,9 @@ class TabView extends HTMLElement
     if @isItemPending()
       @itemTitle.classList.add('temp')
       @classList.add('pending-tab')
+
+    @ondrag = (e) -> layout.drag e
+    @ondragend = (e) -> layout.end e
 
   handleEvents: ->
     titleChangedHandler = =>

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -1,0 +1,10 @@
+.layout-overlay {
+  background: grey;
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  transition: all 0.2s;
+  &.visible {
+    opacity: 0.1;
+  }
+}

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -1,4 +1,4 @@
-.layout-overlay {
+.tabs-layout-overlay {
   background: grey;
   position: absolute;
   opacity: 0;


### PR DESCRIPTION
![layout](https://cloud.githubusercontent.com/assets/2234614/12613448/bb0a7bf8-c4f1-11e5-94f9-d8ff22b9f0ff.gif)

This kind of UI is really handy for those who are less keyboard-savvy, especially if you have a bunch of plots / workspace panes / consoles etc. open and don't want to remember the right sequence of commands needed to organise things :)

I'm still fairly new to CoffeeScript / Atom development so feedback is definitely appreciated. The global `@lastSplit` approach is a bit weird, but seems to be necessary as the `dragend` event gives different `clientX` and `clientY` coordinates which throws things off. I've aimed for an overlay styling that works well with both light and dark syntax / ui themes, but other suggestions are appreciated there as well.