### PR TITLE
Add the abitlity to pin tabs

### DIFF
--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -181,10 +181,12 @@ class TabView extends HTMLElement
 
   updateIcon: ->
     if @iconName
-      @itemTitle.classList.remove('icon', "icon-#{@iconName}")
+      @itemTitle.classList.remove("icon-#{@iconName}")
 
     if @iconName = @item.getIconName?()
-      @itemTitle.classList.add('icon', "icon-#{@iconName}")
+      @itemTitle.classList.add("icon-#{@iconName}")
+
+    @itemTitle.classList.toggle('icon', @iconName)
 
   getTabs: ->
     @parentElement?.querySelectorAll('.tab') ? []
@@ -262,5 +264,18 @@ class TabView extends HTMLElement
     @repoSubscriptions?.dispose()
     delete @status
     @updateVcsColoring()
+
+  setPinnedStatus: (@pinned) ->
+    @classList.toggle('pinned', @pinned)
+    @updateIcon()
+
+  pin: ->
+    @setPinnedStatus(true)
+
+  unpin: ->
+    @setPinnedStatus(false)
+
+  togglePin: ->
+    @setPinnedStatus(not @pinned)
 
 module.exports = document.registerElement('tabs-tab', prototype: TabView.prototype, extends: 'li')

--- a/menus/tabs.cson
+++ b/menus/tabs.cson
@@ -3,6 +3,7 @@ menu: [
     label: 'File'
     submenu: [
       {label: 'Close All Tabs', command: 'tabs:close-all-tabs'}
+      {label: 'Toggle pin tab', command: 'tabs:toggle-pin-tab'}
     ]
   }
 ]
@@ -27,4 +28,10 @@ menu: [
   ]
   '.tab-bar': [
     {label: 'Reopen Closed Tab', command: 'pane:reopen-closed-item'}
+  ]
+  '.tab.pinned': [
+    {label: 'Unpin Tab', command: 'tabs:unpin-tab'}
+  ]
+  '.tab:not(.pinned)': [
+    {label: 'Pin Tab', command: 'tabs:pin-tab'}
   ]

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -378,51 +378,70 @@ describe "TabBarView", ->
       expect(tabBar.getTabs().map (tab) -> tab.textContent).toEqual ["sample.js", "Item 2", "Item 1"]
 
   describe "context menu commands", ->
+
+    pinnedItem = null
+
     beforeEach ->
       paneElement = atom.views.getView(pane)
       paneElement.insertBefore(tabBar, paneElement.firstChild)
       jasmine.attachToDOM(paneElement) # Remove after Atom 1.2.0 is released
+      pinnedItem = new TestView('Pinned item', null)
+      pane.addItem(pinnedItem)
+      triggerMouseEvent('mousedown', tabBar.tabForItem(pinnedItem), which: 3)
+      atom.commands.dispatch(tabBar, 'tabs:pin-tab')
 
     describe "when tabs:close-tab is fired", ->
       it "closes the active tab", ->
         triggerMouseEvent('mousedown', tabBar.tabForItem(item2), which: 3)
         atom.commands.dispatch(tabBar, 'tabs:close-tab')
-        expect(pane.getItems().length).toBe 2
+        expect(pane.getItems().length).toBe 3
         expect(pane.getItems().indexOf(item2)).toBe -1
-        expect(tabBar.getTabs().length).toBe 2
+        expect(tabBar.getTabs().length).toBe 3
         expect($(tabBar).find('.tab:contains(Item 2)')).not.toExist()
 
+      describe "on a pinned tab", ->
+        it "closes the active tab", ->
+          triggerMouseEvent('mousedown', tabBar.tabForItem(pinnedItem), which: 3)
+          atom.commands.dispatch(tabBar, 'tabs:close-tab')
+          expect(pane.getItems().length).toBe 3
+          expect(pane.getItems().indexOf(pinnedItem)).toBe -1
+          expect(tabBar.getTabs().length).toBe 3
+          expect($(tabBar).find('.tab:contains(Pinned item)')).not.toExist()
+
     describe "when tabs:close-other-tabs is fired", ->
-      it "closes all other tabs except the active tab", ->
+      it "closes all other tabs except the active and pinned tabs", ->
         triggerMouseEvent('mousedown', tabBar.tabForItem(item2), which: 3)
         atom.commands.dispatch(tabBar, 'tabs:close-other-tabs')
-        expect(pane.getItems().length).toBe 1
-        expect(tabBar.getTabs().length).toBe 1
+        expect(pane.getItems().length).toBe 2
+        expect(tabBar.getTabs().length).toBe 2
         expect($(tabBar).find('.tab:contains(sample.js)')).not.toExist()
         expect($(tabBar).find('.tab:contains(Item 2)')).toExist()
+        expect($(tabBar).find('.tab:contains(Pinned item)')).toExist()
 
     describe "when tabs:close-tabs-to-right is fired", ->
-      it "closes only the tabs to the right of the active tab", ->
+      it "closes only the tabs to the right of the active and pinned tabs", ->
         pane.activateItem(editor1)
         triggerMouseEvent('mousedown', tabBar.tabForItem(editor1), which: 3)
         atom.commands.dispatch(tabBar, 'tabs:close-tabs-to-right')
-        expect(pane.getItems().length).toBe 2
-        expect(tabBar.getTabs().length).toBe 2
+        expect(pane.getItems().length).toBe 3
+        expect(tabBar.getTabs().length).toBe 3
         expect($(tabBar).find('.tab:contains(Item 2)')).not.toExist()
         expect($(tabBar).find('.tab:contains(Item 1)')).toExist()
+        expect($(tabBar).find('.tab:contains(Pinned item)')).toExist()
 
     describe "when tabs:close-all-tabs is fired", ->
-      it "closes all the tabs", ->
+      it "closes all the tabs except pinned ones", ->
         expect(pane.getItems().length).toBeGreaterThan 0
         atom.commands.dispatch(tabBar, 'tabs:close-all-tabs')
-        expect(pane.getItems().length).toBe 0
+        expect(pane.getItems().length).toBe 1
 
     describe "when tabs:close-saved-tabs is fired", ->
-      it "closes all the saved tabs", ->
+      it "closes all the saved tabs except pinned ones", ->
         item1.isModified = -> true
         atom.commands.dispatch(tabBar, 'tabs:close-saved-tabs')
-        expect(pane.getItems().length).toBe 1
+        expect(pane.getItems().length).toBe 2
         expect(pane.getItems()[0]).toBe item1
+        expect(pane.getItems()[1]).toBe pinnedItem
 
     describe "when tabs:split-up is fired", ->
       it "splits the selected tab up", ->
@@ -514,6 +533,17 @@ describe "TabBarView", ->
         atom.commands.dispatch(paneElement, 'tabs:close-saved-tabs')
         expect(pane.getItems().length).toBe 1
         expect(pane.getItems()[0]).toBe item1
+
+    describe "when tabs:toggle-pin-tab is fired", ->
+      it "pins the active tab", ->
+        atom.commands.dispatch(paneElement, 'tabs:toggle-pin-tab')
+        expect($(tabBar).find('.tab.pinned:contains(Item 2)')).toExist()
+
+      describe "on an already pinned tab", ->
+        it "unpins the active tab", ->
+          atom.commands.dispatch(paneElement, 'tabs:toggle-pin-tab')
+          atom.commands.dispatch(paneElement, 'tabs:toggle-pin-tab')
+          expect($(tabBar).find('.tab.pinned:contains(Item 2)')).not.toExist()
 
   describe "dragging and dropping tabs", ->
     describe "when a tab is dragged within the same pane", ->

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -63,6 +63,17 @@
       border: 2px solid @background-color-info;
       border-radius: 12px;
     }
+
+    &.pinned {
+
+      .title {
+        font-weight: bold;
+      }
+
+      &:not(:hover) .close-icon {
+        .octicon(lock, @close-icon-size);
+      }
+    }
   }
 
   /* Drag and Drop */


### PR DESCRIPTION
![pinned](https://cloud.githubusercontent.com/assets/228886/13053920/eb188904-d3fe-11e5-9647-1695390484c6.gif)

This adds 3 commands:

* `tabs:pin-tab`
* `tabs:unpin-tab`
* `tabs:toggle-pin-tab`

This adds the `Toggle pin tab` command to both palette commands and as
`File` sub menu.

This adds the `Pin Tab` or `Unpin Tab` context menu to tabs (depending
on current status)

Pinned tabs titles are bolden and a `lock` icon is shown (only if `showIcon` is true, overrides existing icon)

Pinned tabs are **not** closed on following events:

* close-all-tabs
* close-other-tabs
* close-tabs-to-right
* close-saved-tabs

_Note:_ pinned tabs are still closed on the regular `close-tab` command

PR comes with updated tests and new ones.