### PR TITLE
Close tab on OSX when corresponding file is moved to trash

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -59,6 +59,7 @@ class TabBarView extends HTMLElement
 
     @subscriptions.add @pane.onDidAddItem ({item, index}) =>
       @addTabForItem(item, index)
+      @subscribeToTabPath(item)
 
     @subscriptions.add @pane.onDidMoveItem ({item, newIndex}) =>
       @moveItemTabToIndex(item, newIndex)
@@ -85,6 +86,12 @@ class TabBarView extends HTMLElement
   unsubscribe: ->
     ipcRenderer.removeListener('tab:dropped', @onDropOnOtherWindow)
     @subscriptions.dispose()
+
+  subscribeToTabPath: (item) ->
+    if typeof item.buffer?.onDidChangePath is 'function'
+      @subscriptions.add item.buffer?.onDidChangePath (path) =>
+        if process.platform is 'darwin' and /.Trash/.test(path)
+          @closeTab(@tabForItem(item))
 
   terminatePendingStates: ->
     tab.terminatePendingState?() for tab in @getTabs()


### PR DESCRIPTION
Fixes #160 
Closes all tabs corresponding to a given file if it's moved to trash.

To test:

1. Create a new file
2. (optional) Split into an additional pane
3. Right click on the file in the tree and Delete->Move to Trash

Questions:

- where best to check for platform
- most rigorous way to check path