### PR TITLE
Add support for new pending item API

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -92,7 +92,7 @@ class TabBarView extends HTMLElement
 
   addTabForItem: (item, index) ->
     tabView = new TabView()
-    tabView.initialize(item)
+    tabView.initialize(item, @pane)
     tabView.terminatePendingState() if @isItemMovingBetweenPanes
     @insertTabAtIndex(tabView, index)
 

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -6,7 +6,6 @@ class TabView extends HTMLElement
   initialize: (@item, @pane) ->
     if typeof @item.getPath is 'function'
       @path = @item.getPath()
-      @isPendingTab = @isItemPending()
 
     @classList.add('tab', 'sortable')
 
@@ -27,7 +26,7 @@ class TabView extends HTMLElement
     @updateModifiedStatus()
     @setupTooltip()
 
-    if @isPendingTab
+    if @pane.getPendingItem() is @item
       @itemTitle.classList.add('temp')
       @classList.add('pending-tab')
 
@@ -37,9 +36,10 @@ class TabView extends HTMLElement
       @updateTitle()
       @updateTooltip()
 
-    if typeof @pane.onDidTerminatePendingState is 'function'
-      @subscriptions.add @pane.onDidTerminatePendingState =>
-        @clearPending() if @isPendingTab and not @isItemPending()
+    # TODO: remove else condition once pending API is on stable [MKT]
+    if typeof @pane.onItemDidTerminatePendingState is 'function'
+      @subscriptions.add @pane.onItemDidTerminatePendingState (item) =>
+        @clearPending() if item is @item
     else if typeof @item.onDidTerminatePendingState is 'function'
       onDidTerminatePendingStateDisposable = @item.onDidTerminatePendingState => @clearPending()
       if Disposable.isDisposable(onDidTerminatePendingStateDisposable)
@@ -205,7 +205,6 @@ class TabView extends HTMLElement
       @item.terminatePendingState()
 
   clearPending: ->
-    @isPendingTab = false
     @itemTitle.classList.remove('temp')
     @classList.remove('pending-tab')
 

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -26,7 +26,7 @@ class TabView extends HTMLElement
     @updateModifiedStatus()
     @setupTooltip()
 
-    if @pane.getPendingItem() is @item
+    if @isItemPending()
       @itemTitle.classList.add('temp')
       @classList.add('pending-tab')
 

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -910,25 +910,6 @@ describe "TabBarView", ->
           runs ->
             expect($(tabBar.tabForItem(editor1)).find('.title')).not.toHaveClass 'temp'
 
-      describe "when switching from a pending tab to a permanent tab", ->
-        it "keeps the pending tab open", ->
-          editor1 = null
-          editor2 = null
-
-          waitsForPromise ->
-            atom.workspace.open('sample.txt').then (o) ->
-              editor1 = o
-
-          waitsForPromise ->
-            atom.workspace.open('sample2.txt', pending: true).then (o) ->
-              editor2 = o
-
-          runs ->
-            pane.activateItem(editor1)
-            expect(pane.getItems().length).toBe 2
-            expect(pane.getItems()).toEqual [editor1, editor2]
-            expect($(tabBar.tabForItem(editor2)).find('.title')).toHaveClass 'temp'
-
       describe "when splitting a pending tab", ->
         editor1 = null
         beforeEach ->


### PR DESCRIPTION
This adds backward-compatible checks for the new pending item APIs, and falls back to using `Item::terminatePendingState`, etc. if they're not supported in the current Atom environment.

Related to atom/atom#10995, this allows `tabs` to continue to provide visual feedback on item pendingness with both the old and new APIs; will eventually be replaced by #268.

/cc @kuychaco 