### PR TITLE
Fix behavior of split panes when `alwaysShowTabBar` is false

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -17,7 +17,9 @@ class TabBarView extends HTMLElement
   initialize: (@pane) ->
     @subscriptions = new CompositeDisposable
 
-    @subscriptions.add atom.commands.add atom.views.getView(@pane),
+    @paneView = atom.views.getView(@pane)
+
+    @subscriptions.add atom.commands.add @paneView,
       'tabs:keep-pending-tab': => @terminatePendingStates()
       'tabs:close-tab': => @closeTab(@getActiveTab())
       'tabs:close-other-tabs': => @closeOtherTabs(@getActiveTab())
@@ -50,6 +52,10 @@ class TabBarView extends HTMLElement
     @addEventListener "dragleave", @onDragLeave
     @addEventListener "dragover", @onDragOver
     @addEventListener "drop", @onDrop
+
+    if not atom.config.get('tabs.alwaysShowTabBar')
+      @paneView.addEventListener "dragover", =>
+        @classList.remove('hidden')
 
     @paneContainer = @pane.getContainer()
     @addTabForItem(item) for item in @pane.getItems()
@@ -177,7 +183,10 @@ class TabBarView extends HTMLElement
     @windowId ?= atom.getCurrentWindow().id
 
   shouldAllowDrag: ->
-    (@paneContainer.getPanes().length > 1) or (@pane.getItems().length > 1)
+    if not atom.config.get('tabs.alwaysShowTabBar')
+      (@pane.getItems().length > 1)
+    else
+      (@paneContainer.getPanes().length > 1) or (@pane.getItems().length > 1)
 
   onDragStart: (event) ->
     return unless matches(event.target, '.sortable')

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -54,8 +54,7 @@ class TabBarView extends HTMLElement
     @addEventListener "drop", @onDrop
 
     if not atom.config.get('tabs.alwaysShowTabBar')
-      @paneView.addEventListener "dragover", =>
-        @unhideBar()
+      @paneView.addEventListener "dragover", @onPaneDragOver.bind(this)
 
     @paneContainer = @pane.getContainer()
     @addTabForItem(item) for item in @pane.getItems()
@@ -124,13 +123,17 @@ class TabBarView extends HTMLElement
   updateTabBarVisibility: ->
     if not atom.config.get('tabs.alwaysShowTabBar') and not @shouldAllowDrag()
       @classList.add('hidden')
-      @paneView.addEventListener "dragover", =>
-        @unhideBar()
+      @paneView.addEventListener 'dragover', @onPaneDragOver.bind(this)
+
     else
       @classList.remove('hidden')
-      @paneView.removeEventListener "dragover", @unhideBar
+      @paneView.removeEventListener 'dragover', @onPaneDragOver
+
+  onPaneDragOver: ->
+    @unhideBar()
 
   unhideBar: ->
+    return unless @classList.contains('hidden')
     @classList.remove('hidden')
 
   getTabs: ->

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -55,7 +55,7 @@ class TabBarView extends HTMLElement
 
     if not atom.config.get('tabs.alwaysShowTabBar')
       @paneView.addEventListener "dragover", =>
-        @classList.remove('hidden')
+        @unhideBar()
 
     @paneContainer = @pane.getContainer()
     @addTabForItem(item) for item in @pane.getItems()
@@ -124,8 +124,14 @@ class TabBarView extends HTMLElement
   updateTabBarVisibility: ->
     if not atom.config.get('tabs.alwaysShowTabBar') and not @shouldAllowDrag()
       @classList.add('hidden')
+      @paneView.addEventListener "dragover", =>
+        @unhideBar()
     else
       @classList.remove('hidden')
+      @paneView.removeEventListener "dragover", @unhideBar
+
+  unhideBar: ->
+    @classList.remove('hidden')
 
   getTabs: ->
     tab for tab in @querySelectorAll(".tab")

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -124,7 +124,6 @@ class TabBarView extends HTMLElement
     if not atom.config.get('tabs.alwaysShowTabBar') and not @shouldAllowDrag()
       @classList.add('hidden')
       @paneView.addEventListener 'dragover', @onPaneDragOver.bind(this)
-
     else
       @classList.remove('hidden')
       @paneView.removeEventListener 'dragover', @onPaneDragOver

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -129,9 +129,6 @@ class TabBarView extends HTMLElement
       @paneView.removeEventListener 'dragover', @onPaneDragOver
 
   onPaneDragOver: ->
-    @unhideBar()
-
-  unhideBar: ->
     return unless @classList.contains('hidden')
     @classList.remove('hidden')
 

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -656,6 +656,66 @@ describe "TabBarView", ->
           expect(pane2.activeItem).toBe item1
           expect(pane2.activate).toHaveBeenCalled()
 
+      describe "when alwaysShowTabBar is set to false in package settings", ->
+        beforeEach: ->
+          atom.config.set('tabs.alwaysShowTabBar', false)
+
+        afterEach: ->
+          atom.config.set('tabs.alwaysShowTabBar', true)
+
+        describe "when target pane has one tab", ->
+          it "starts with tab bar hidden then reveals it", ->
+            expect(tabBar.getTabs().map (tab) -> tab.textContent).toEqual ["Item 1", "sample.js", "Item 2"]
+            expect(pane.getItems()).toEqual [item1, editor1, item2]
+            expect(pane.getActiveItem()).toBe item2
+
+            expect(tabBar2).toHaveClass 'hidden'
+            expect(tabBar2.getTabs().map (tab) -> tab.textContent).toEqual ["Item 2"]
+            expect(pane2.getItems()).toEqual [item2b]
+            expect(pane2.activeItem).toBe item2b
+            spyOn(pane2, 'activate')
+
+            [dragStartEvent, dropEvent] = buildDragEvents(tabBar.tabAtIndex(0), tabBar2.tabAtIndex(0))
+            tabBar.onDragStart(dragStartEvent)
+            tabBar2.onDrop(dropEvent)
+
+            expect(tabBar.getTabs().map (tab) -> tab.textContent).toEqual ["sample.js", "Item 2"]
+            expect(pane.getItems()).toEqual [editor1, item2]
+            expect(pane.getActiveItem()).toBe item2
+
+            expect(tabBar2.getTabs().map (tab) -> tab.textContent).toEqual ["Item 2", "Item 1"]
+            expect(pane2.getItems()).toEqual [item2b, item1]
+            expect(pane2.activeItem).toBe item1
+            expect(pane2.activate).toHaveBeenCalled()
+            expect(tabBar2).not.toHaveClass 'hidden'
+
+        describe "when source pane has only two tabs", ->
+          it "hides the tab bar after dragging one tab away", ->
+            pane.destroyItem(editor1)
+            expect(tabBar.getTabs().map (tab) -> tab.textContent).toEqual ["Item 1", "Item 2"]
+            expect(pane.getItems()).toEqual [item1, item2]
+            expect(pane.getActiveItem()).toBe item2
+
+            expect(tabBar2.getTabs().map (tab) -> tab.textContent).toEqual ["Item 2"]
+            expect(pane2.getItems()).toEqual [item2b]
+            expect(pane2.activeItem).toBe item2b
+            spyOn(pane2, 'activate')
+
+            [dragStartEvent, dropEvent] = buildDragEvents(tabBar.tabAtIndex(0), tabBar2.tabAtIndex(0))
+            tabBar.onDragStart(dragStartEvent)
+            tabBar2.onDrop(dropEvent)
+
+            expect(tabBar.getTabs().map (tab) -> tab.textContent).toEqual ["Item 2"]
+            expect(pane.getItems()).toEqual [item2]
+            expect(pane.getActiveItem()).toBe item2
+            expect(tabBar).toHaveClass 'hidden'
+
+            expect(tabBar2.getTabs().map (tab) -> tab.textContent).toEqual ["Item 2", "Item 1"]
+            expect(pane2.getItems()).toEqual [item2b, item1]
+            expect(pane2.activeItem).toBe item1
+            expect(pane2.activate).toHaveBeenCalled()
+            expect(tabBar2).not.toHaveClass 'hidden'
+
     describe "when a non-tab is dragged to pane", ->
       it "has no effect", ->
         expect(tabBar.getTabs().map (tab) -> tab.textContent).toEqual ["Item 1", "sample.js", "Item 2"]


### PR DESCRIPTION
fixes #275 
makes a couple changes:
1. update logic in `shouldAllowDrag` so that when a split pane has only one tab the tab bar becomes `hidden`
2. add listener so dragging a tab into a pane view unhides the tab bar
![hide-tab-bar](https://cloud.githubusercontent.com/assets/6645121/13506365/6e74f8e0-e143-11e5-919a-079682a993e6.gif)