### PR TITLE
fix update data-path, data-name after change title event

### DIFF
--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -34,6 +34,9 @@ class TabView extends HTMLElement
 
   handleEvents: ->
     titleChangedHandler = =>
+      if typeof @item.getPath is 'function'
+        @path = @item.getPath()
+
       @updateDataAttributes()
       @updateTitle()
       @updateTooltip()


### PR DESCRIPTION
This commit fixes bug with old data-name, data-path attributes after renaming file or folder.
