### PR TITLE
Resize tabs when mouse moves away from tab bar

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -46,6 +46,8 @@ class TabBarView extends HTMLElement
       'tabs:split-left': => @splitTab('splitLeft')
       'tabs:split-right': => @splitTab('splitRight')
 
+    @addEventListener "mouseenter", @onMouseEnter
+    @addEventListener "mouseleave", @onMouseLeave
     @addEventListener "dragstart", @onDragStart
     @addEventListener "dragend", @onDragEnd
     @addEventListener "dragleave", @onDragLeave
@@ -163,7 +165,7 @@ class TabBarView extends HTMLElement
     @closeTab(tab)
     pathsToOpen = [atom.project.getPaths(), itemURI].reduce ((a, b) -> a.concat(b)), []
     atom.open({pathsToOpen: pathsToOpen, newWindow: true, devMode: atom.devMode, safeMode: atom.safeMode})
-  
+
   splitTab: (fn) ->
     if item = @querySelector('.right-clicked')?.item
       if copiedItem = @copyItem(item)
@@ -458,5 +460,15 @@ class TabBarView extends HTMLElement
       target
     else
       closest(target, '.tab-bar')
+
+  onMouseEnter: ->
+    for tab in @getTabs()
+      {width} = tab.getBoundingClientRect()
+      tab.style.maxWidth = width.toFixed(2) + 'px'
+    return
+
+  onMouseLeave: ->
+    tab.style.maxWidth = '' for tab in @getTabs()
+    return
 
 module.exports = document.registerElement("atom-tabs", prototype: TabBarView.prototype, extends: "ul")

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -101,6 +101,28 @@ describe "TabBarView", ->
   afterEach ->
     deserializerDisposable.dispose()
 
+  describe "when the mouse is moved over the tab bar", ->
+    it "fixes the width on every tab", ->
+      jasmine.attachToDOM(tabBar)
+
+      event = triggerMouseEvent('mouseenter', tabBar)
+
+      initialWidth1 = tabBar.tabAtIndex(0).getBoundingClientRect().width.toFixed(2)
+      initialWidth2 = tabBar.tabAtIndex(2).getBoundingClientRect().width.toFixed(2)
+
+      expect(tabBar.tabAtIndex(0).style.maxWidth).toBe initialWidth1 + 'px'
+      expect(tabBar.tabAtIndex(2).style.maxWidth).toBe initialWidth2 + 'px'
+
+  describe "when the mouse is moved away from the tab bar", ->
+    it "resets the width on every tab", ->
+      jasmine.attachToDOM(tabBar)
+
+      event = triggerMouseEvent('mouseenter', tabBar)
+      event = triggerMouseEvent('mouseleave', tabBar)
+
+      expect(tabBar.tabAtIndex(0).style.maxWidth).toBe ''
+      expect(tabBar.tabAtIndex(1).style.maxWidth).toBe ''
+
   describe ".initialize(pane)", ->
     it "creates a tab for each item on the tab bar's parent pane", ->
       expect(pane.getItems().length).toBe 3

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -17,6 +17,7 @@
     -webkit-flex: 1;
     max-width: 175px;
     min-width: 40px;
+    transition: max-width .25s ease-in;
 
     &.active {
       -webkit-flex: 2;


### PR DESCRIPTION
Here's an implementation of the Chrome tabs functionality required in issue #129.

Functionality added...

- Each tab has it's maxWidth set to it's current width when the mouse enters the tabbarview
- Each tab has it's maxWidth set to '' when the mouse leaves the tabbarview