### PR TITLE
Correctly adjust pane index when adding with `addNewTabsAtEnd` config

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -95,10 +95,9 @@ class TabBarView extends HTMLElement
     tabView = new TabView()
     tabView.initialize(item, @pane)
     tabView.terminatePendingState() if @isItemMovingBetweenPanes
+    @insertTabAtIndex(tabView, index)
     if atom.config.get('tabs.addNewTabsAtEnd')
-      @appendChild(tabView)
-    else
-      @insertTabAtIndex(tabView, index)
+      @pane.moveItem(item, @pane.getItems().length - 1)
 
   moveItemTabToIndex: (item, index) ->
     if tab = @tabForItem(item)
@@ -163,7 +162,7 @@ class TabBarView extends HTMLElement
     @closeTab(tab)
     pathsToOpen = [atom.project.getPaths(), itemURI].reduce ((a, b) -> a.concat(b)), []
     atom.open({pathsToOpen: pathsToOpen, newWindow: true, devMode: atom.devMode, safeMode: atom.safeMode})
-  
+
   splitTab: (fn) ->
     if item = @querySelector('.right-clicked')?.item
       if copiedItem = @copyItem(item)

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -188,6 +188,12 @@ describe "TabBarView", ->
         expect($(tabBar).find('.tab').length).toBe 4
         expect($(tabBar.tabAtIndex(3)).find('.title')).toHaveText 'Item 3'
 
+      it "puts the new tab at the last index of the pane's items", ->
+        atom.config.set("tabs.addNewTabsAtEnd", true)
+        item3 = new TestView('Item 3')
+        pane.activateItem(item3)
+        expect(pane.getItems()[pane.getItems().length - 1]).toEqual item3
+
     describe "when addNewTabsAtEnd is set to false in package settings", ->
       it "adds a tab for the new item at the same index as the item in the pane", ->
         atom.config.set("tabs.addNewTabsAtEnd", false)

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -191,6 +191,8 @@ describe "TabBarView", ->
       it "puts the new tab at the last index of the pane's items", ->
         atom.config.set("tabs.addNewTabsAtEnd", true)
         item3 = new TestView('Item 3')
+        # activate item1 so default is to add immediately after
+        pane.activateItem(item1)
         pane.activateItem(item3)
         expect(pane.getItems()[pane.getItems().length - 1]).toEqual item3
 


### PR DESCRIPTION
Fixes a bug found by @maxnowack [here](https://github.com/atom/tabs/pull/276#issuecomment-210360700).
Moving tabs to the end wasn't adjusting their index in the pane, so iterating over them was out of order. 
Adding a new tab at the end calls the pane's `moveItem` method to change its position in the pane, which is then reflected in the tab bar.
The previous specs for this were only examining the tab bar's items, not the pane's items, so I added a spec which ensures that an added item is the last in the pane.

cc @lee-dohm 