### PR TITLE
Consume file icon service

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@
 Display selectable tabs above the editor.
 
 ![](https://cloud.githubusercontent.com/assets/18362/10862852/c6de2de0-800d-11e5-8158-284f30aaf5d2.png)
+
+## API
+
+Tabs can display icons next to file names. These icons are customizable by installing a package that provides an `atom.file-icons` service.
+
+The `atom.file-icons` service must provide the following methods:
+
+* `iconClassForPath(path)` - Returns a CSS class name to add to the tab view
+* `onWillDeactivate` - An event that lets the tabs return to their default icon strategy

--- a/lib/default-file-icons.coffee
+++ b/lib/default-file-icons.coffee
@@ -1,0 +1,4 @@
+class DefaultFileIcons
+  iconClassForPath: (filePath) -> ''
+
+module.exports = DefaultFileIcons

--- a/lib/file-icons.coffee
+++ b/lib/file-icons.coffee
@@ -1,0 +1,15 @@
+DefaultFileIcons = require './default-file-icons'
+
+class FileIcons
+  constructor: ->
+    @service = new DefaultFileIcons
+
+  getService: ->
+    @service
+
+  resetService: ->
+    @service = new DefaultFileIcons
+
+  setService: (@service) ->
+
+module.exports = new FileIcons

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,3 +1,5 @@
+FileIcons = require './file-icons'
+
 module.exports =
   activate: (state) ->
     @tabBarViews = []
@@ -17,5 +19,10 @@ module.exports =
 
   deactivate: ->
     @paneSubscription.dispose()
+    @fileIconsDisposable?.dispose()
     tabBarView.remove() for tabBarView in @tabBarViews
     return
+
+  consumeFileIcons: (service) ->
+    FileIcons.setService(service)
+    @fileIconsDisposable = service.onWillDeactivate -> FileIcons.resetService()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -25,4 +25,11 @@ module.exports =
 
   consumeFileIcons: (service) ->
     FileIcons.setService(service)
-    @fileIconsDisposable = service.onWillDeactivate -> FileIcons.resetService()
+    @fileIconsDisposable = service.onWillDeactivate ->
+      FileIcons.resetService()
+      @updateFileIcons()
+    @updateFileIcons()
+
+  updateFileIcons: ->
+    for tabBarView in @tabBarViews
+      tabView.updateIcon() for tabView in tabBarView.getTabs()

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -1,6 +1,5 @@
 BrowserWindow = null # Defer require until actually used
-# TODO: Remove the catch once Electron 0.35.0 is bundled in Atom
-try {ipcRenderer} = require 'electron' catch then ipcRenderer = require 'ipc'
+{ipcRenderer} = require 'electron'
 
 {matches, closest, indexOf} = require './html-helpers'
 {CompositeDisposable} = require 'atom'
@@ -163,7 +162,7 @@ class TabBarView extends HTMLElement
     @closeTab(tab)
     pathsToOpen = [atom.project.getPaths(), itemURI].reduce ((a, b) -> a.concat(b)), []
     atom.open({pathsToOpen: pathsToOpen, newWindow: true, devMode: atom.devMode, safeMode: atom.safeMode})
-  
+
   splitTab: (fn) ->
     if item = @querySelector('.right-clicked')?.item
       if copiedItem = @copyItem(item)
@@ -390,10 +389,7 @@ class TabBarView extends HTMLElement
       @removeEventListener 'mousewheel', @onMouseWheel
 
   browserWindowForId: (id) ->
-    try
-      BrowserWindow ?= require('electron').remote.BrowserWindow
-    catch # TODO: Remove once Electron 0.35.0 is bundled in Atom
-      BrowserWindow ?= require('remote').require('browser-window')
+    BrowserWindow ?= require('electron').remote.BrowserWindow
 
     BrowserWindow.fromId id
 

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -1,5 +1,6 @@
 path = require 'path'
 {Disposable, CompositeDisposable} = require 'atom'
+FileIcons = require './file-icons'
 
 module.exports =
 class TabView extends HTMLElement
@@ -188,7 +189,7 @@ class TabView extends HTMLElement
     if @iconName
       @itemTitle.classList.remove('icon', "icon-#{@iconName}")
 
-    if @iconName = @item.getIconName?()
+    if @iconName = @item.getIconName?() or @path? and @iconName = FileIcons.getService().iconClassForPath(@path)
       @itemTitle.classList.add('icon', "icon-#{@iconName}")
 
   getTabs: ->

--- a/package.json
+++ b/package.json
@@ -12,6 +12,13 @@
     "temp": "~0.8.1",
     "underscore-plus": "1.x"
   },
+  "consumedServices": {
+    "atom.file-icons": {
+      "versions": {
+        "1.0.0": "consumeFileIcons"
+      }
+    }
+  },
   "configSchema": {
     "showIcons": {
       "type": "boolean",

--- a/spec/default-file-icons-spec.coffee
+++ b/spec/default-file-icons-spec.coffee
@@ -1,0 +1,15 @@
+DefaultFileIcons = require '../lib/default-file-icons'
+
+describe 'DefaultFileIcons', ->
+  [fileIcons] = []
+
+  beforeEach ->
+    fileIcons = new DefaultFileIcons
+
+  it 'does not provide icons out of the box', ->
+    expect(fileIcons.iconClassForPath('foo.bar')).toEqual('')
+    expect(fileIcons.iconClassForPath('README.md')).toEqual('')
+    expect(fileIcons.iconClassForPath('foo.zip')).toEqual('')
+    expect(fileIcons.iconClassForPath('foo.png')).toEqual('')
+    expect(fileIcons.iconClassForPath('foo.pdf')).toEqual('')
+    expect(fileIcons.iconClassForPath('foo.exe')).toEqual('')

--- a/spec/file-icons-spec.coffee
+++ b/spec/file-icons-spec.coffee
@@ -1,0 +1,23 @@
+DefaultFileIcons = require '../lib/default-file-icons'
+FileIcons = require '../lib/file-icons'
+
+describe 'FileIcons', ->
+  afterEach ->
+    FileIcons.setService(new DefaultFileIcons)
+
+  it 'provides a default', ->
+    expect(FileIcons.getService()).toBeDefined()
+    expect(FileIcons.getService()).not.toBeNull()
+
+  it 'allows the default to be overridden', ->
+    service = new Object
+    FileIcons.setService(service)
+
+    expect(FileIcons.getService()).toBe(service)
+
+  it 'allows the service to be reset to the default easily', ->
+    service = new Object
+    FileIcons.setService(service)
+    FileIcons.resetService()
+
+    expect(FileIcons.getService()).not.toBe(service)


### PR DESCRIPTION
Consume `atom.file-icons` service to display icons next to file names. This is based on https://github.com/atom/atom/issues/9820 and has been suggested by @lee-dohm. Another example is available in https://github.com/atom/tree-view/pull/490.

Current behavior has been kept.