### PR TITLE
Get entire icon CSS class from file icon service

### DIFF
--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -190,6 +190,8 @@ class TabView extends HTMLElement
       @itemTitle.classList.remove('icon', "icon-#{@iconName}")
 
     if @iconName = @item.getIconName?() or @path? and @iconName = FileIcons.getService().iconClassForPath(@path)
+      # File icons service will return an entire CSS class
+      @iconName = @iconName.replace('icon-', '')
       @itemTitle.classList.add('icon', "icon-#{@iconName}")
 
   getTabs: ->


### PR DESCRIPTION
`tree-view` and `tabs` were expecting different outputs from the service. Sorry about that :sweat_smile: 