### PR TITLE
Improve logic for consuming file-icons

### DIFF
--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -187,7 +187,7 @@ class TabView extends HTMLElement
 
   updateIcon: ->
     if @iconName
-      names = @iconName.split /\s+/g
+      names = unless Array.isArray(@iconName) then @iconName.split(/\s+/g) else @iconName
       @itemTitle.classList.remove('icon', "icon-#{names[0]}", names...)
 
     if @iconName = @item.getIconName?()

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -192,7 +192,7 @@ class TabView extends HTMLElement
 
     if @iconName = @item.getIconName?()
       @itemTitle.classList.add('icon', "icon-#{@iconName}")
-    else if @path? and @iconName = FileIcons.getService().iconClassForPath(@path)
+    else if @path? and @iconName = FileIcons.getService().iconClassForPath(@path, @)
       unless Array.isArray names = @iconName
         names = names.toString().split /\s+/g
       

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -187,12 +187,16 @@ class TabView extends HTMLElement
 
   updateIcon: ->
     if @iconName
-      @itemTitle.classList.remove('icon', "icon-#{@iconName}")
+      names = @iconName.split /\s+/g
+      @itemTitle.classList.remove('icon', "icon-#{names[0]}", names...)
 
-    if @iconName = @item.getIconName?() or @path? and @iconName = FileIcons.getService().iconClassForPath(@path)
-      # File icons service will return an entire CSS class
-      @iconName = @iconName.replace('icon-', '')
+    if @iconName = @item.getIconName?()
       @itemTitle.classList.add('icon', "icon-#{@iconName}")
+    else if @path? and @iconName = FileIcons.getService().iconClassForPath(@path)
+      unless Array.isArray names = @iconName
+        names = names.toString().split /\s+/g
+      
+      @itemTitle.classList.add('icon', names...)
 
   getTabs: ->
     @parentElement?.querySelectorAll('.tab') ? []

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -192,7 +192,7 @@ class TabView extends HTMLElement
 
     if @iconName = @item.getIconName?()
       @itemTitle.classList.add('icon', "icon-#{@iconName}")
-    else if @path? and @iconName = FileIcons.getService().iconClassForPath(@path, @)
+    else if @path? and @iconName = FileIcons.getService().iconClassForPath(@path, this)
       unless Array.isArray names = @iconName
         names = names.toString().split /\s+/g
       

--- a/spec/file-icons-spec.coffee
+++ b/spec/file-icons-spec.coffee
@@ -52,3 +52,10 @@ describe 'FileIcons', ->
       tab = workspaceElement.querySelector('.tab')
       tab.updateIcon()
       expect(tab.itemTitle.className).toBe('title icon first second')
+
+    it 'passes a TabView reference as iconClassForPath\'s second argument', ->
+      FileIcons.setService
+        iconClassForPath: (path, tab) -> tab.constructor.name
+      tab = workspaceElement.querySelector('.tab')
+      tab.updateIcon()
+      expect(tab.itemTitle.className).toBe('title icon tabs-tab')

--- a/spec/file-icons-spec.coffee
+++ b/spec/file-icons-spec.coffee
@@ -21,3 +21,34 @@ describe 'FileIcons', ->
     FileIcons.resetService()
 
     expect(FileIcons.getService()).not.toBe(service)
+
+
+  describe 'Class handling', ->
+    workspaceElement = null
+    
+    beforeEach ->
+      workspaceElement = atom.views.getView(atom.workspace)
+      
+      waitsForPromise ->
+        atom.workspace.open('sample.js')
+        
+      waitsForPromise ->
+        atom.packages.activatePackage('tabs')
+  
+    it 'allows multiple classes to be passed', ->
+      service =
+        iconClassForPath: (path) -> 'first second'
+      
+      FileIcons.setService(service)
+      tab = workspaceElement.querySelector('.tab')
+      tab.updateIcon()
+      expect(tab.itemTitle.className).toBe('title icon first second')
+
+    it 'allows an array of classes to be passed', ->
+      service =
+        iconClassForPath: (path) -> ['first', 'second']
+      
+      FileIcons.setService(service)
+      tab = workspaceElement.querySelector('.tab')
+      tab.updateIcon()
+      expect(tab.itemTitle.className).toBe('title icon first second')


### PR DESCRIPTION
Two problems currently exist with the package's handling of file-icons:

1. **Everything is prefixed with `icon-`**  
This is limiting for authors, who may have CSS classes named differently. It's also inconsistent with the behaviour of the `tree-panes` package, which performs no such prefixing on class-names.<br/><br/>
2. **Only one class name can be set by the service**  
Again, this is very limiting for packages that may need to add more than one class at a time (such as one for the icon, and another for its colour).

This PR alters the existing logic so that
- `icon-` prefixes are limited to "core" panels only (e.g., items with a `getIconName` method defined)
- multiple classes can be supplied by services as either an array or space-delimited list