### PR TITLE
Fix auto-reveal scrolling when adding new tab at end

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -100,9 +100,9 @@ class TabBarView extends HTMLElement
     tabView = new TabView()
     tabView.initialize(item, @pane)
     tabView.terminatePendingState() if @isItemMovingBetweenPanes
-    @insertTabAtIndex(tabView, index)
     if atom.config.get('tabs.addNewTabsAtEnd')
-      @pane.moveItem(item, @pane.getItems().length - 1) unless @isItemMovingBetweenPanes
+      index = (@pane.getItems().length - 1) unless @isItemMovingBetweenPanes
+    @insertTabAtIndex(tabView, index)
 
   moveItemTabToIndex: (item, index) ->
     if tab = @tabForItem(item)

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -212,7 +212,7 @@ describe "TabBarView", ->
       it "adds a tab for the new item at the end of the tab bar", ->
         atom.config.set("tabs.addNewTabsAtEnd", true)
         item3 = new TestView('Item 3')
-        pane.activateItem(item3)
+        pane.addItem(item3)
         expect($(tabBar).find('.tab').length).toBe 4
         expect($(tabBar.tabAtIndex(3)).find('.title')).toHaveText 'Item 3'
 
@@ -220,8 +220,9 @@ describe "TabBarView", ->
         atom.config.set("tabs.addNewTabsAtEnd", true)
         item3 = new TestView('Item 3')
         # activate item1 so default is to add immediately after
-        pane.activateItem(item1)
-        pane.activateItem(item3)
+        pane.addItem(item1)
+        pane.addItem(item3)
+        console.log(pane.getItems())
         expect(pane.getItems()[pane.getItems().length - 1]).toEqual item3
 
     describe "when addNewTabsAtEnd is set to false in package settings", ->


### PR DESCRIPTION
There was an issue with the call to moveItem focusing a temporary tab when adding a new tab at the end. This caused the tree-view to change scroll between the first click and second click of a double click event, meaning the wrong item could be accidentally clicked.

Fixes https://github.com/atom/tree-view/issues/867

Thanks to @Ben3eeE for finding this
