### PR TITLE
Use package's name to identify context of icon-service

### DIFF
--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -212,7 +212,7 @@ class TabView extends HTMLElement
 
     if @iconName = @item.getIconName?()
       @itemTitle.classList.add('icon', "icon-#{@iconName}")
-    else if @path? and @iconName = FileIcons.getService().iconClassForPath(@path, this)
+    else if @path? and @iconName = FileIcons.getService().iconClassForPath(@path, "tabs")
       unless Array.isArray names = @iconName
         names = names.toString().split /\s+/g
       

--- a/spec/file-icons-spec.coffee
+++ b/spec/file-icons-spec.coffee
@@ -53,9 +53,9 @@ describe 'FileIcons', ->
       tab.updateIcon()
       expect(tab.itemTitle.className).toBe('title icon first second')
 
-    it 'passes a TabView reference as iconClassForPath\'s second argument', ->
+    it 'passes the package name as iconClassForPath\'s second argument', ->
       FileIcons.setService
-        iconClassForPath: (path, tab) -> tab.constructor.name
+        iconClassForPath: (path, context) -> context
       tab = workspaceElement.querySelector('.tab')
       tab.updateIcon()
-      expect(tab.itemTitle.className).toBe('title icon tabs-tab')
+      expect(tab.itemTitle.className).toBe('title icon tabs')


### PR DESCRIPTION
**TL;DR:** This is [just fixing something I botched](https://github.com/atom/tabs/pull/319).

Formal explanation / Recap
--------------------------
Some packages may need to know *where* an icon will be used before returning a class. For example, the File-Icons package has a setting to disable icons in file tabs... in order to hide the icon though, we need to ensure the request isn't originating from the `tree-view`.

I [originally dealt with](https://github.com/atom/tabs/pull/319/files#diff-c22b992a1f1147b70fd5608ee4146a36) this issue by passing the calling TabView object as a secondary argument to `.iconClassForPath`. This gave package authors full access to the calling object's properties, allowing them to glean whatever they needed to know at that point in time.

I planned to use the same approach for [`tree-view`](https://github.com/atom/tree-view/pull/825), but [that didn't go down well](https://github.com/atom/tree-view/pull/825#discussion-diff-71882708) with @as-cii, who criticised the inelegance of my approach. He suggested implementing a `disableCustomIcons` setting for `tree-view` and `tabs`, but I realised that could [add complications in future](https://github.com/atom/tree-view/pull/825#issuecomment-236122813).

I decided the most rational approach is to simply include the name of the consuming package in the service call. That way, service-providers can tell when an icon's being requested by the `tabs` package or `tree-view`, and tailor their output accordingly.

Related pull requests
---------------------
* atom/fuzzy-finder#249

Other PRs for adding icon-service consumption that've not yet been merged have already been updated to include this new behaviour.