### PR TITLE
Read pane/item directly off tab element instead of looking up via DOM

### DIFF
--- a/lib/layout.coffee
+++ b/lib/layout.coffee
@@ -1,4 +1,4 @@
-{closest, indexOf, matches} = require './html-helpers'
+{closest, matches} = require './html-helpers'
 
 module.exports =
 
@@ -35,9 +35,9 @@ module.exports =
       when 'down'  then target.splitDown()
     tab = e.target
     toPane ?= target
-    fromPane = @paneForTab tab
+    fromPane = tab.pane
     return if toPane is fromPane
-    item = @itemForTab tab
+    item = tab.item
     fromPane.moveItemToPane item, toPane
     toPane.activateItem item
     toPane.activate()
@@ -51,14 +51,8 @@ module.exports =
   getPaneAt: (coords) ->
     @test.pane or @getElement(@lastCoords, 'atom-pane')?.getModel()
 
-  paneForTab: (tab) ->
-    tab.parentElement.pane
-
-  itemForTab: (tab) ->
-    @paneForTab(tab).getItems()[indexOf(tab)]
-
   isOnlyTabInPane: (pane, tab) ->
-    pane.getItems().length is 1 and pane is @paneForTab tab
+    pane.getItems().length is 1 and pane is tab.pane
 
   normalizeCoords: ({left, top, width, height}, [x, y]) ->
     [(x-left)/width, (y-top)/height]


### PR DESCRIPTION
Determining a tab’s pane or item via the DOM is unnecessary because we store this state directly on each tab. It was leading to exceptions in cases where a tab’s pane was being removed as a side-effect of dragging because the tab didn’t have a parent element. This happens when the `core.removeEmptyPanes` config setting is enabled.

Fixes #332