### PR TITLE
Automatically scroll to tab if not completely visible when activating a pane item

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -124,15 +124,6 @@ class TabBarView extends HTMLElement
     tab.updateTitle() for tab in @getTabs()
     @updateTabBarVisibility()
 
-  scrollToTab: (tab) ->
-    tabRightEdge = tab.offsetLeft + tab.clientWidth
-    tabBarRightEdge = this.scrollLeft + this.clientWidth
-
-    if tabRightEdge > tabBarRightEdge
-      this.scrollLeft = tabRightEdge - this.clientWidth
-    else if this.scrollLeft > tab.offsetLeft
-      this.scrollLeft = tab.offsetLeft
-
   updateTabBarVisibility: ->
     if not atom.config.get('tabs.alwaysShowTabBar') and not @shouldAllowDrag()
       @classList.add('hidden')
@@ -152,7 +143,7 @@ class TabBarView extends HTMLElement
     if tabView? and not tabView.classList.contains('active')
       @querySelector('.tab.active')?.classList.remove('active')
       tabView.classList.add('active')
-      @scrollToTab(tabView)
+      tabView.scrollIntoView()
 
   getActiveTab: ->
     @tabForItem(@pane.getActiveItem())

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -124,6 +124,15 @@ class TabBarView extends HTMLElement
     tab.updateTitle() for tab in @getTabs()
     @updateTabBarVisibility()
 
+  scrollToTab: (tab) ->
+    tabRightEdge = tab.offsetLeft + tab.clientWidth
+    tabBarRightEdge = this.scrollLeft + this.clientWidth
+
+    if tabRightEdge > tabBarRightEdge
+      this.scrollLeft = tabRightEdge - this.clientWidth
+    else if this.scrollLeft > tab.offsetLeft
+      this.scrollLeft = tab.offsetLeft
+
   updateTabBarVisibility: ->
     if not atom.config.get('tabs.alwaysShowTabBar') and not @shouldAllowDrag()
       @classList.add('hidden')
@@ -143,7 +152,7 @@ class TabBarView extends HTMLElement
     if tabView? and not tabView.classList.contains('active')
       @querySelector('.tab.active')?.classList.remove('active')
       tabView.classList.add('active')
-      tabView.scrollIntoView()
+      @scrollToTab(tabView)
 
   getActiveTab: ->
     @tabForItem(@pane.getActiveItem())

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -115,6 +115,8 @@ class TabBarView extends HTMLElement
       @insertBefore(tab, followingTab)
     else
       @appendChild(tab)
+
+    @scrollToTab(tab)
     tab.updateTitle()
     @updateTabBarVisibility()
 
@@ -122,6 +124,15 @@ class TabBarView extends HTMLElement
     @tabForItem(item)?.destroy()
     tab.updateTitle() for tab in @getTabs()
     @updateTabBarVisibility()
+
+  scrollToTab: (tab) ->
+    tabRightEdge = tab.offsetLeft + tab.offsetWidth
+    tabBarRightEdge = this.scrollLeft + this.offsetWidth
+
+    if tabRightEdge > tabBarRightEdge
+      this.scrollLeft = tabRightEdge - this.offsetWidth
+    else if this.scrollLeft > tab.offsetLeft
+      this.scrollLeft = tab.offsetLeft
 
   updateTabBarVisibility: ->
     if not atom.config.get('tabs.alwaysShowTabBar') and not @shouldAllowDrag()
@@ -142,6 +153,7 @@ class TabBarView extends HTMLElement
     if tabView? and not tabView.classList.contains('active')
       @querySelector('.tab.active')?.classList.remove('active')
       tabView.classList.add('active')
+      @scrollToTab(tabView)
 
   getActiveTab: ->
     @tabForItem(@pane.getActiveItem())

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -116,7 +116,6 @@ class TabBarView extends HTMLElement
     else
       @appendChild(tab)
 
-    @scrollToTab(tab)
     tab.updateTitle()
     @updateTabBarVisibility()
 
@@ -126,11 +125,11 @@ class TabBarView extends HTMLElement
     @updateTabBarVisibility()
 
   scrollToTab: (tab) ->
-    tabRightEdge = tab.offsetLeft + tab.offsetWidth
-    tabBarRightEdge = this.scrollLeft + this.offsetWidth
+    tabRightEdge = tab.offsetLeft + tab.clientWidth
+    tabBarRightEdge = this.scrollLeft + this.clientWidth
 
     if tabRightEdge > tabBarRightEdge
-      this.scrollLeft = tabRightEdge - this.offsetWidth
+      this.scrollLeft = tabRightEdge - this.clientWidth
     else if this.scrollLeft > tab.offsetLeft
       this.scrollLeft = tab.offsetLeft
 

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -310,6 +310,48 @@ describe "TabBarView", ->
       expect(tabBar.getTabs().length).toBe 2
       expect($(tabBar).find('.tab:contains(sample.js)')).not.toExist()
 
+  describe "scrollToTab", ->
+    [item3] = []
+    beforeEach ->
+      item3 = new TestView("Item 3")
+      pane.activateItem(item3)
+
+      # Set up styles so the tab bar has a scrollbar
+      tabBar.style.display = 'flex'
+      tabBar.style.overflowX = 'scroll'
+      tabBar.style.margin = '0'
+
+      container = document.createElement('div')
+      container.style.width = '150px'
+      container.appendChild(tabBar)
+      jasmine.attachToDOM(container)
+
+      # Expect there to be content to scroll
+      expect(tabBar.scrollWidth).toBeGreaterThan tabBar.clientWidth
+
+    it "does not scroll new active pane item is completely visible", ->
+      pane.activateItem(item1)
+      expect(tabBar.scrollLeft).toBe 0
+
+      pane.activateItem(editor1)
+      expect(tabBar.scrollLeft).toBe 0
+
+      pane.activateItem(item2)
+      expect(tabBar.scrollLeft).toBe 0
+
+      pane.activateItem(item3)
+      expect(tabBar.scrollLeft).not.toBe 0
+
+    it "scrolls when the new active pane item is not completely visible", ->
+      tabBar.scrollLeft = 5
+      expect(tabBar.scrollLeft).toBe 5 # This can be 0 if there is no horizontal scrollbar
+
+      pane.activateItem(item1)
+      expect(tabBar.scrollLeft).toBe 0
+
+      pane.activateItem(item3)
+      expect(tabBar.scrollLeft).toBe tabBar.scrollWidth - tabBar.clientWidth
+
   describe "when a tab item's title changes", ->
     it "updates the title of the item's tab", ->
       editor1.buffer.setPath('/this/is-a/test.txt')

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -309,7 +309,7 @@ describe "TabBarView", ->
       expect(tabBar.getTabs().length).toBe 2
       expect($(tabBar).find('.tab:contains(sample.js)')).not.toExist()
 
-  describe "scrollToTab", ->
+  describe "when an item is activated", ->
     [item3] = []
     beforeEach ->
       item3 = new TestView("Item 3")
@@ -328,7 +328,7 @@ describe "TabBarView", ->
       # Expect there to be content to scroll
       expect(tabBar.scrollWidth).toBeGreaterThan tabBar.clientWidth
 
-    it "does not scroll new active pane item is completely visible", ->
+    it "does not scroll to the item when it is visible", ->
       pane.activateItem(item1)
       expect(tabBar.scrollLeft).toBe 0
 
@@ -341,7 +341,7 @@ describe "TabBarView", ->
       pane.activateItem(item3)
       expect(tabBar.scrollLeft).not.toBe 0
 
-    it "scrolls when the new active pane item is not completely visible", ->
+    it "scrolls to the item when it isn't completely visible", ->
       tabBar.scrollLeft = 5
       expect(tabBar.scrollLeft).toBe 5 # This can be 0 if there is no horizontal scrollbar
 


### PR DESCRIPTION
Closes https://github.com/atom/tabs/issues/138

When a tab is out of view automatically scroll to that tab when activated. Current behavior is to scroll so the left or right edge is shown depending on direction.

Gifs of behavior says more than 1000 words.

## New behavior
![new activiate out of view](https://cloud.githubusercontent.com/assets/1058982/18446281/07a1f236-7922-11e6-9be6-11ac49ee10ea.gif)
![new activiate out of view other dir](https://cloud.githubusercontent.com/assets/1058982/18446297/106d6670-7922-11e6-88bb-946d13b7f21f.gif)
![ctrl tab](https://cloud.githubusercontent.com/assets/1058982/18446637/863372ae-7923-11e6-8ef0-7ff0f0628b04.gif)

## Old behavior
![old activiate out of view](https://cloud.githubusercontent.com/assets/1058982/18446276/014218b2-7922-11e6-901e-ef2495dc1793.gif)
![old activiate out of view other dir](https://cloud.githubusercontent.com/assets/1058982/18446286/0cc80958-7922-11e6-80c9-5298fca9f9da.gif)