### PR TITLE
Fix drop marker position

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -68,28 +68,36 @@
 
   /* Drag and Drop */
   .placeholder {
-    position: absolute;
+    position: relative;
     top: 0;
-    z-index: 999;
-    display: inline-block;
-    width: 2px;
-    margin: -1px; padding: 0;
-
+    padding: 0;
     height: @tab-height;
-    display: inline-block;
-    background: @background-color-info;
-
+    z-index: 999;
     list-style: none;
+    background: @background-color-info;
+    pointer-events: none;
 
+    // bar
+    &:before {
+      content: "";
+      position: absolute;
+      width: 2px;
+      margin: -1px; padding: 0;
+      height: inherit;
+      background: inherit;
+    }
+
+    // dot
     &:after {
       content: "";
       position: absolute;
       top: @tab-height;
-      margin: -1px;
+      margin-top: -1px;
+      margin-left: -2px;
       z-index: 9999;
       width: 4px;
       height: 4px;
-      background: @background-color-info;
+      background: inherit;
       border-radius: 4px;
       border: 1px solid transparent;
     }


### PR DESCRIPTION
This fixes the position of the drop marker (that blue bar) when dragging.

![blue_tab_dropping_indicator_480](https://cloud.githubusercontent.com/assets/378023/19205354/e06f18e2-8d1c-11e6-9b10-f68b23fdf6dc.gif)

I think the reason is that in recent Chromium, absolutely positioned flexbox items disregard sibling items. See https://developers.google.com/web/updates/2016/06/absolute-positioned-children

Fixes #383