### PR TITLE
Close tabs on middle mouse click instead of middle mouse down

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -390,10 +390,7 @@ class TabBarView extends HTMLElement
     return unless matches(event.target, ".tab")
 
     tab = closest(event.target, '.tab')
-    if event.which is 2
-      @pane.destroyItem(tab.item)
-      event.preventDefault()
-    else if event.target.classList.contains('close-icon')
+    if event.which is 2 or event.target.classList.contains('close-icon')
       @pane.destroyItem(tab.item)
       event.preventDefault()
 

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -377,9 +377,6 @@ class TabBarView extends HTMLElement
     else if event.which is 1 and not event.target.classList.contains('close-icon')
       @pane.activateItem(tab.item)
       setImmediate => @pane.activate() unless @pane.isDestroyed()
-    else if event.which is 2
-      @pane.destroyItem(tab.item)
-      event.preventDefault()
 
   onDoubleClick: (event) ->
     if tab = closest(event.target, '.tab')
@@ -390,11 +387,15 @@ class TabBarView extends HTMLElement
       event.preventDefault()
 
   onClick: (event) ->
-    return unless matches(event.target, ".tab .close-icon")
+    return unless matches(event.target, ".tab")
 
     tab = closest(event.target, '.tab')
-    @pane.destroyItem(tab.item)
-    false
+    if event.which is 2
+      @pane.destroyItem(tab.item)
+      event.preventDefault()
+    else if event.target.classList.contains('close-icon')
+      @pane.destroyItem(tab.item)
+      event.preventDefault()
 
   updateTabScrollingThreshold: ->
     @tabScrollingThreshold = atom.config.get('tabs.tabScrollingThreshold')

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -273,7 +273,7 @@ describe "TabBarView", ->
     it "closes the tab when middle clicked", ->
       jasmine.attachToDOM(tabBar) # Remove after Atom 1.2.0 is released
 
-      event = triggerMouseEvent('mousedown', tabBar.tabForItem(editor1), which: 2)
+      event = triggerMouseEvent('click', tabBar.tabForItem(editor1), which: 2)
 
       expect(pane.getItems().length).toBe 2
       expect(pane.getItems().indexOf(editor1)).toBe -1


### PR DESCRIPTION
Fixes https://github.com/atom/tabs/issues/198

Current behavior is to close tab on middle mouse down, this changes it to close on click instead. Gives the user a chance to change their mind about closing which feels like a better behavior.
