### PR TITLE
Added a setting to enable/disable the MRU tab list

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -38,7 +38,7 @@ module.exports =
         atom.keymaps.add(keyBindSource, disabledBindings, 0)
 
     @updateTabListSubscription = ->
-      if atom.config.get(mruConfigKey) && atom.config.get(listConfigKey)
+      if atom.config.get(mruConfigKey) and atom.config.get(listConfigKey)
         subscriptions =
           for location, container of paneContainers
             continue unless container
@@ -46,7 +46,7 @@ module.exports =
         @tabListPaneSubscription = new CompositeDisposable(subscriptions...)
       else
         mruListView.destroy() for mruListView in @mruListViews
-        @tabListPaneSubscription && @tabListPaneSubscription.dispose()
+        @tabListPaneSubscription.dispose() if @tabListPaneSubscription
 
     @registerTabBarPanes = (pane) =>
       tabBarView = new TabBarView(pane, location)
@@ -67,7 +67,7 @@ module.exports =
     atom.keymaps.onDidLoadUserKeymap? => @updateTraversalKeybinds()
     atom.config.observe mruConfigKey, =>
       @updateTraversalKeybinds()
-      atom.config.get(listConfigKey) && @updateTabListSubscription()
+      @updateTabListSubscription() if atom.config.get(listConfigKey)
 
     atom.config.observe listConfigKey, => @updateTabListSubscription()
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,12 @@
       "title": "Enable MRU Tab Switching",
       "default": true,
       "description": "Enable tab switching in most-recently-used order. This setting has no effect if ctrl-tab or ctrl-shift-tab are already rebound via your keymap or another package."
+    },
+    "enableMruTabList": {
+      "type": "boolean",
+      "title": "Enable MRU Tab List While Switching Tabs",
+      "default": true,
+      "description": "Enable a tab list while switching in most-recently-used order. This setting has no effect if MRU tab switching is disabled."
     }
   },
   "devDependencies": {


### PR DESCRIPTION
### Description of the Change

Added a setting to enable/disable the tab list that appears when using MRU tab switching. In this implementation the list is coupled to MRU tab switching. I didn't make it a separate setting since the point of the list seemed to be to give more context when using MRU, and it would be annoying to have a list when using sequential tab switching.

The code design is fairly simple and just plugs in to what was already in place for MRU tab switching.

### Alternate Designs

I thought about making the tab list an independent setting from MRU but decided against it after reading the discussion around the feature.

### Benefits

You'll be able to decide whether you want the tab list or not! User choice!!

### Possible Drawbacks

I don't think so but too much choice???

### Applicable Issues

Didn't see any