### PR TITLE
Pass all (newly) required params to PaneContainer constructor

### DIFF
--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -989,7 +989,10 @@ describe "TabBarView", ->
 
         # Create a new pane container.
         PaneContainer = atom.workspace.paneContainer.constructor
-        paneContainer = new PaneContainer config: atom.config
+        paneContainer = new PaneContainer
+          applicationDelegate: atom.applicationDelegate
+          config: atom.config
+          viewRegistry: atom.views
         pane2 = paneContainer.getActivePane()
         tabBar2 = new TabBarView(pane2)
 


### PR DESCRIPTION
atom/atom#13977 associates a PaneContainer with its element via the
`getElement()` method (instead of the view registry). As a result,
PaneContainer must be provided with the application delegate and view
registry.

This fixes an error in that PR's tests.