### PR TITLE
Allowed Locations & Permanent Dock Items

### DIFF
--- a/lib/layout.coffee
+++ b/lib/layout.coffee
@@ -13,7 +13,8 @@ module.exports =
     @lastCoords = e
     pane = @getPaneAt e
     itemView = @getItemViewAt e
-    if pane? and itemView?
+    item = e.target.item
+    if pane? and itemView? and item and itemIsAllowedInPane(item, pane)
       coords = if not (@isOnlyTabInPane(pane, e.target) or pane.getItems().length is 0)
         [e.clientX, e.clientY]
       @lastSplit = @updateView itemView, coords
@@ -35,6 +36,7 @@ module.exports =
     fromPane = tab.pane
     return if toPane is fromPane
     item = tab.item
+    return unless itemIsAllowedInPane(item, toPane)
     fromPane.moveItemToPane item, toPane
     toPane.activateItem item
     toPane.activate()
@@ -90,3 +92,10 @@ module.exports =
 
   disableView: ->
     @view.classList.remove 'visible'
+
+itemIsAllowedInPane = (item, pane) ->
+  allowedLocations = item.getAllowedLocations?()
+  return true unless allowedLocations?
+  container = pane.getContainer()
+  location = container.getLocation?() ? 'center'
+  return location in allowedLocations

--- a/lib/layout.coffee
+++ b/lib/layout.coffee
@@ -26,17 +26,17 @@ module.exports =
     return unless @lastCoords? and @getItemViewAt @lastCoords
     target = @getPaneAt @lastCoords
     return unless target?
+    tab = e.target
+    fromPane = tab.pane
+    item = tab.item
+    return unless itemIsAllowedInPane(item, toPane ? target)
     toPane = switch @lastSplit
       when 'left'  then target.splitLeft()
       when 'right' then target.splitRight()
       when 'up'    then target.splitUp()
       when 'down'  then target.splitDown()
-    tab = e.target
     toPane ?= target
-    fromPane = tab.pane
     return if toPane is fromPane
-    item = tab.item
-    return unless itemIsAllowedInPane(item, toPane)
     fromPane.moveItemToPane item, toPane
     toPane.activateItem item
     toPane.activate()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,4 +1,4 @@
-{Disposable} = require 'atom'
+{CompositeDisposable, Disposable} = require 'atom'
 FileIcons = require './file-icons'
 layout = require './layout'
 TabBarView = require './tab-bar-view'
@@ -48,18 +48,29 @@ module.exports =
         for tabBarView in @tabBarViews by -1
           tabBarView.closeAllTabs()
 
-    @paneSubscription = atom.workspace.observePanes (pane) =>
-      tabBarView = new TabBarView(pane)
-      mruListView = new MRUListView
-      mruListView.initialize(pane)
+    paneContainers =
+      center: atom.workspace.getCenter?() ? atom.workspace
+      left: atom.workspace.getLeftDock?()
+      right: atom.workspace.getRightDock?()
+      bottom: atom.workspace.getBottomDock?()
 
-      paneElement = atom.views.getView(pane)
-      paneElement.insertBefore(tabBarView.element, paneElement.firstChild)
+    subscriptions =
+      for location, container of paneContainers
+        continue unless container
+        container.observePanes (pane) =>
+          tabBarView = new TabBarView(pane, location)
+          mruListView = new MRUListView
+          mruListView.initialize(pane)
 
-      @tabBarViews.push(tabBarView)
-      pane.onDidDestroy => _.remove(@tabBarViews, tabBarView)
-      @mruListViews.push(mruListView)
-      pane.onDidDestroy => _.remove(@mruListViews, mruListView)
+          paneElement = atom.views.getView(pane)
+          paneElement.insertBefore(tabBarView.element, paneElement.firstChild)
+
+          @tabBarViews.push(tabBarView)
+          pane.onDidDestroy => _.remove(@tabBarViews, tabBarView)
+          @mruListViews.push(mruListView)
+          pane.onDidDestroy => _.remove(@mruListViews, mruListView)
+
+    @paneSubscription = new CompositeDisposable(subscriptions...)
 
   deactivate: ->
     layout.deactivate()

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -260,6 +260,9 @@ class TabBarView
     else if typeof item.getUri is 'function'
       itemURI = item.getUri() ? ''
 
+    if typeof item.getAllowedLocations is 'function'
+      event.dataTransfer.setData 'allowed-locations', item.getAllowedLocations().join('|')
+
     if itemURI?
       event.dataTransfer.setData 'text/plain', itemURI
 
@@ -336,6 +339,8 @@ class TabBarView
     fromPaneId    = parseInt(event.dataTransfer.getData('from-pane-id'))
     fromIndex     = parseInt(event.dataTransfer.getData('sortable-index'))
     fromPaneIndex = parseInt(event.dataTransfer.getData('from-pane-index'))
+    allowedLocations = (event.dataTransfer.getData('allowed-locations') or '').trim()
+    itemIsAllowed = not allowedLocations or allowedLocations.split('|').includes(@location)
 
     hasUnsavedChanges = event.dataTransfer.getData('has-unsaved-changes') is 'true'
     modifiedText = event.dataTransfer.getData('modified-text')
@@ -344,6 +349,8 @@ class TabBarView
     toPane = @pane
 
     @clearDropTarget()
+
+    return unless itemIsAllowed
 
     if fromWindowId is @getWindowId()
       fromPane = @paneContainer.getPanes()[fromPaneIndex]

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -7,7 +7,7 @@ TabView = require './tab-view'
 
 module.exports =
 class TabBarView
-  constructor: (@pane) ->
+  constructor: (@pane, @location) ->
     @element = document.createElement('ul')
     @element.classList.add("list-inline")
     @element.classList.add("tab-bar")
@@ -107,6 +107,7 @@ class TabBarView
       didClickCloseIcon: =>
         @closeTab(tabView)
         return
+      @location
     })
     tabView.terminatePendingState() if @isItemMovingBetweenPanes
     @tabsByElement.set(tabView.element, tabView)

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -6,7 +6,7 @@ layout = require './layout'
 
 module.exports =
 class TabView
-  constructor: ({@item, @pane, didClickCloseIcon, @tabs}) ->
+  constructor: ({@item, @pane, didClickCloseIcon, @tabs, location}) ->
     if typeof @item.getPath is 'function'
       @path = @item.getPath()
 
@@ -20,10 +20,11 @@ class TabView
     @itemTitle.classList.add('title')
     @element.appendChild(@itemTitle)
 
-    closeIcon = document.createElement('div')
-    closeIcon.classList.add('close-icon')
-    closeIcon.onclick = didClickCloseIcon
-    @element.appendChild(closeIcon)
+    if location is 'center' or not @item.isPermanentDockItem?()
+      closeIcon = document.createElement('div')
+      closeIcon.classList.add('close-icon')
+      closeIcon.onclick = didClickCloseIcon
+      @element.appendChild(closeIcon)
 
     @subscriptions = new CompositeDisposable()
 


### PR DESCRIPTION
These address the feedback in atom/atom#13977 by:

1. Only adding the close icon for dock item when `isPermanentDockItem()` returns `false` (or is absent).
2. Only allowing an item to be dropped into tab bars and panes if its `getAllowedLocations()` method includes the location (or is absent).

I updated layout to not show the overlay over disallowed locations. It would be nice to also change the cursor from copy to `no-drop` then too, but I couldn't find where this was being done.