### PR TITLE
Set z-index on overlay so that it covers the docks

### DIFF
--- a/styles/layout.less
+++ b/styles/layout.less
@@ -1,6 +1,7 @@
 .tabs-layout-overlay {
   background: grey;
   position: absolute;
+  z-index: 11; // Make sure this covers absolutely-positioned docks
   opacity: 0;
   pointer-events: none;
   transition: all 0.2s;


### PR DESCRIPTION
This goes with atom/atom#13977 and makes sure that the overlay is
visible when dragging items into closed docks.

Discussed with @simurai in that thread 😊