### PR TITLE
Fix missing drop indicator on Electron >= 1.14

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -285,7 +285,7 @@ class TabBarView
     @clearDropTarget()
 
   onDragOver: (event) ->
-    unless event.dataTransfer.getData('atom-event') is 'true'
+    unless @isAtomEvent(event)
       event.preventDefault()
       event.stopPropagation()
       return
@@ -499,3 +499,10 @@ class TabBarView
         return tab
       else
         currentElement = currentElement.parentElement
+
+  isAtomEvent: (event) ->
+    for item in event.dataTransfer.items
+      if item.type is 'atom-event'
+        return true
+
+    return false

--- a/spec/event-helpers.coffee
+++ b/spec/event-helpers.coffee
@@ -18,6 +18,13 @@ module.exports.buildDragEvents = (dragged, dropTarget) ->
     setData: (key, value) -> @data[key] = "#{value}" # Drag events stringify data values
     getData: (key) -> @data[key]
 
+  Object.defineProperty(
+    dataTransfer,
+    'items',
+    get: ->
+      Object.keys(dataTransfer.data).map((key) -> {type: key})
+  )
+
   dragStartEvent = buildMouseEvent("dragstart", dragged)
   Object.defineProperty(dragStartEvent, 'dataTransfer', get: -> dataTransfer)
 


### PR DESCRIPTION
The security model of new Chromium versions forbids all event listeners, except for `onDragStart` and `onDrop`, to inspect the data values that have been previously set on the event's `dataTransfer` object.

To circumvent this problem we can exploit the fact that all we need to do is checking whether a boolean has been set or not. To do so, we will simply list all the items contained in the `dataTransfer` object and read their `type` property (that we use as a dictionary key), verifying that at least one of them contains the key we are searching for.

Before: 
![screen shot 2017-03-29 at 16 39 09](https://cloud.githubusercontent.com/assets/482957/24460340/4ec864b6-149e-11e7-80d0-fd6070979deb.png)

After: 
![screen shot 2017-03-29 at 16 38 57](https://cloud.githubusercontent.com/assets/482957/24460339/4ec6c156-149e-11e7-8e29-a8eaa53cc4ee.png)

/cc: @atom/maintainers 