### PR TITLE
Fix mistakenly shown docks drop indicator on Electron >= 1.4

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -261,7 +261,10 @@ class TabBarView
       itemURI = item.getUri() ? ''
 
     if typeof item.getAllowedLocations is 'function'
-      event.dataTransfer.setData 'allowed-locations', item.getAllowedLocations().join('|')
+      for location in item.getAllowedLocations()
+        event.dataTransfer.setData("allowed-location-#{location}", 'true')
+    else
+      event.dataTransfer.setData 'allow-all-locations', 'true'
 
     if itemURI?
       event.dataTransfer.setData 'text/plain', itemURI
@@ -289,7 +292,7 @@ class TabBarView
     @clearDropTarget()
 
   onDragOver: (event) ->
-    unless @isAtomEvent(event)
+    unless isAtomEvent(event)
       event.preventDefault()
       event.stopPropagation()
       return
@@ -507,13 +510,16 @@ class TabBarView
       else
         currentElement = currentElement.parentElement
 
-  isAtomEvent: (event) ->
-    for item in event.dataTransfer.items
-      if item.type is 'atom-event'
-        return true
+isAtomEvent = (event) ->
+  for item in event.dataTransfer.items
+    if item.type is 'atom-event'
+      return true
 
-    return false
+  return false
 
 itemIsAllowed = (event, location) ->
-  allowedLocations = (event.dataTransfer.getData('allowed-locations') or '').trim()
-  not allowedLocations or allowedLocations.split('|').includes(location)
+  for item in event.dataTransfer.items
+    if item.type is 'allow-all-locations' or item.type is "allowed-location-#{location}"
+      return true
+
+  return false

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -1061,22 +1061,28 @@ describe "TabBarView", ->
           expect(pane2.activeItem).toBe item1
           expect(atom.workspace.getLeftDock().isVisible()).toBe(true)
 
-        describe "when the tab's item is not allowed in that pane container", ->
-          it "does not show a placeholder or allow the tab be dropped", ->
-            item1.getAllowedLocations = -> ['center', 'bottom']
+        it "shows a placeholder and allows the tab be dropped only if the item supports the target pane container location", ->
+          item1.getAllowedLocations = -> ['center', 'bottom']
+          [dragStartEvent, dropEvent] = buildDragEvents(tabBar.tabAtIndex(0).element, tabBar2.element)
+          tabBar.onDragStart(dragStartEvent)
+          expect(tabBar2.element.querySelector('.placeholder')).toBeNull()
+          tabBar2.onDragOver(dropEvent)
+          expect(tabBar2.element.querySelector('.placeholder')).toBeNull()
+          tabBar2.onDrop(dropEvent)
+          expect(tabBar2.element.querySelector('.placeholder')).toBeNull()
+          expect(pane.getItems()).toEqual [item1, editor1, item2]
+          expect(pane2.getItems()).toEqual [dockItem]
 
-            expect(pane.getItems()).toEqual [item1, editor1, item2]
-            expect(pane2.getItems()).toEqual [dockItem]
-
-            [dragStartEvent, dropEvent] = buildDragEvents(tabBar.tabAtIndex(0).element, tabBar2.element)
-            tabBar.onDragStart(dragStartEvent)
-            expect(tabBar2.element.querySelector('.placeholder')).toBeNull()
-            tabBar2.onDragOver(dropEvent)
-            expect(tabBar2.element.querySelector('.placeholder')).toBeNull()
-            tabBar2.onDrop(dropEvent)
-
-            expect(pane.getItems()).toEqual [item1, editor1, item2]
-            expect(pane2.getItems()).toEqual [dockItem]
+          item1.getAllowedLocations = -> ['left']
+          [dragStartEvent, dropEvent] = buildDragEvents(tabBar.tabAtIndex(0).element, tabBar2.element)
+          tabBar.onDragStart(dragStartEvent)
+          expect(tabBar2.element.querySelector('.placeholder')).toBeNull()
+          tabBar2.onDragOver(dropEvent)
+          expect(tabBar2.element.querySelector('.placeholder')).not.toBeNull()
+          tabBar2.onDrop(dropEvent)
+          expect(tabBar2.element.querySelector('.placeholder')).toBeNull()
+          expect(pane.getItems()).toEqual [editor1, item2]
+          expect(pane2.getItems()).toEqual [dockItem, item1]
 
   describe "when the tab bar is double clicked", ->
     it "opens a new empty editor", ->


### PR DESCRIPTION
This pull request fixes a regression that we were observing on newer Electron versions due to reasons similar to the ones described in #426. In particular, on Electron >= 1.4 we were showing a drop indicator even for dock locations that were unsupported by the dragged item.

Analogously to the aforementioned pull request, in this one we are replacing usages of `dataTransfer.getData` in the `dragover` handler with a scan of the keys present inside the `dataTransfer` object.

/cc: @nathansobo @maxbrunsfeld 