### PR TITLE
Delay activation of item on mousedown event

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -404,8 +404,14 @@ class TabBarView
       @rightClickedTab.element.classList.add('right-clicked')
       event.preventDefault()
     else if event.which is 1 and not event.target.classList.contains('close-icon')
-      @pane.activateItem(tab.item)
-      setImmediate => @pane.activate() unless @pane.isDestroyed()
+      # Delay action. This is important because the browser will set the focus
+      # as part of the default action of the mousedown event; therefore, any
+      # change we make to the focus as part of the handler would be overwritten.
+      # We could use `preventDefault()` to address this, but that would also
+      # make the tab undraggable.
+      setImmediate =>
+        @pane.activateItem(tab.item)
+        @pane.activate() unless @pane.isDestroyed()
     else if event.which is 2
       @pane.destroyItem(tab.item)
       event.preventDefault()

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -261,19 +261,22 @@ describe "TabBarView", ->
       spyOn(pane, 'activate')
 
       event = triggerMouseEvent('mousedown', tabBar.tabAtIndex(0).element, which: 1)
-      expect(pane.getActiveItem()).toBe pane.getItems()[0]
-      expect(event.preventDefault).not.toHaveBeenCalled() # allows dragging
-
-      event = triggerMouseEvent('mousedown', tabBar.tabAtIndex(2).element, which: 1)
-      expect(pane.getActiveItem()).toBe pane.getItems()[2]
-      expect(event.preventDefault).not.toHaveBeenCalled() # allows dragging
-
       # Pane activation is delayed because focus is stolen by the tab bar
       # immediately afterward unless propagation of the mousedown event is
       # stopped. But stopping propagation of the mousedown event prevents the
       # dragstart event from occurring.
-      waits(1)
-      runs -> expect(pane.activate.callCount).toBe 2
+      waitsForPromise -> new Promise setImmediate
+      runs ->
+        expect(pane.getActiveItem()).toBe pane.getItems()[0]
+        expect(event.preventDefault).not.toHaveBeenCalled() # allows dragging
+
+        event = triggerMouseEvent('mousedown', tabBar.tabAtIndex(2).element, which: 1)
+      waitsForPromise -> new Promise setImmediate
+      runs ->
+        expect(pane.getActiveItem()).toBe pane.getItems()[2]
+        expect(event.preventDefault).not.toHaveBeenCalled() # allows dragging
+
+        expect(pane.activate.callCount).toBe 2
 
     it "closes the tab when middle clicked", ->
       jasmine.attachToDOM(tabBar.element) # Remove after Atom 1.2.0 is released

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -265,17 +265,20 @@ describe "TabBarView", ->
       # immediately afterward unless propagation of the mousedown event is
       # stopped. But stopping propagation of the mousedown event prevents the
       # dragstart event from occurring.
-      waitsForPromise -> new Promise setImmediate
-      runs ->
-        expect(pane.getActiveItem()).toBe pane.getItems()[0]
-        expect(event.preventDefault).not.toHaveBeenCalled() # allows dragging
+      expect(pane.getActiveItem()).not.toBe(pane.getItems()[0])
+      waitsFor ->
+        pane.getActiveItem() is pane.getItems()[0]
 
+      runs ->
+        expect(event.preventDefault).not.toHaveBeenCalled() # allows dragging
         event = triggerMouseEvent('mousedown', tabBar.tabAtIndex(2).element, which: 1)
-      waitsForPromise -> new Promise setImmediate
-      runs ->
-        expect(pane.getActiveItem()).toBe pane.getItems()[2]
-        expect(event.preventDefault).not.toHaveBeenCalled() # allows dragging
+        expect(pane.getActiveItem()).not.toBe(pane.getItems()[2])
 
+      waitsFor ->
+        pane.getActiveItem() is pane.getItems()[2]
+
+      runs ->
+        expect(event.preventDefault).not.toHaveBeenCalled() # allows dragging
         expect(pane.activate.callCount).toBe 2
 
     it "closes the tab when middle clicked", ->


### PR DESCRIPTION
Because the item's activation could result in a change of focus, we
need to wait to take it until the event has finished propagating.
Otherwise, the focus will be set by the browser as part of the default
action for the mousedown event.

Sorry there's no test but it doesn't seem possible to simulate the problematic browser behavior and still test what we want to.