### PR TITLE
Tab bar shouldn't be focusable

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -13,7 +13,6 @@ class TabBarView
     @element.classList.add("tab-bar")
     @element.classList.add("inset-panel")
     @element.setAttribute('is', 'atom-tabs')
-    @element.setAttribute("tabindex", -1)
 
     @tabs = []
     @tabsByElement = new WeakMap
@@ -404,14 +403,8 @@ class TabBarView
       @rightClickedTab.element.classList.add('right-clicked')
       event.preventDefault()
     else if event.which is 1 and not event.target.classList.contains('close-icon')
-      # Delay action. This is important because the browser will set the focus
-      # as part of the default action of the mousedown event; therefore, any
-      # change we make to the focus as part of the handler would be overwritten.
-      # We could use `preventDefault()` to address this, but that would also
-      # make the tab undraggable.
-      setImmediate =>
-        @pane.activateItem(tab.item)
-        @pane.activate() unless @pane.isDestroyed()
+      @pane.activateItem(tab.item)
+      @pane.activate() unless @pane.isDestroyed()
     else if event.which is 2
       @pane.destroyItem(tab.item)
       event.preventDefault()

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -261,25 +261,14 @@ describe "TabBarView", ->
       spyOn(pane, 'activate')
 
       event = triggerMouseEvent('mousedown', tabBar.tabAtIndex(0).element, which: 1)
-      # Pane activation is delayed because focus is stolen by the tab bar
-      # immediately afterward unless propagation of the mousedown event is
-      # stopped. But stopping propagation of the mousedown event prevents the
-      # dragstart event from occurring.
-      expect(pane.getActiveItem()).not.toBe(pane.getItems()[0])
-      waitsFor ->
-        pane.getActiveItem() is pane.getItems()[0]
+      expect(pane.getActiveItem()).toBe pane.getItems()[0]
+      expect(event.preventDefault).not.toHaveBeenCalled() # allows dragging
 
-      runs ->
-        expect(event.preventDefault).not.toHaveBeenCalled() # allows dragging
-        event = triggerMouseEvent('mousedown', tabBar.tabAtIndex(2).element, which: 1)
-        expect(pane.getActiveItem()).not.toBe(pane.getItems()[2])
+      event = triggerMouseEvent('mousedown', tabBar.tabAtIndex(2).element, which: 1)
+      expect(pane.getActiveItem()).toBe pane.getItems()[2]
+      expect(event.preventDefault).not.toHaveBeenCalled() # allows dragging
 
-      waitsFor ->
-        pane.getActiveItem() is pane.getItems()[2]
-
-      runs ->
-        expect(event.preventDefault).not.toHaveBeenCalled() # allows dragging
-        expect(pane.activate.callCount).toBe 2
+      expect(pane.activate.callCount).toBe 2
 
     it "closes the tab when middle clicked", ->
       jasmine.attachToDOM(tabBar.element) # Remove after Atom 1.2.0 is released


### PR DESCRIPTION
This was originally added way back in 310c058 however, a tabindex of -1
means that the tab bar can receive focus.

As a result, focus would end up being transferred to the tab bar as
part of the default action of the mousedown handler. When the `Pane` is
activated, it would see that its child (the tab bar) had focus and
leave it there, meaning the tab bar (instead of the editor) would
retain focus. This behavior was first reported in #14173, however the
original fix for it (#14175) resulted in Panes always stealing the
focus from their children. This regression was rectified with
atom/atom#14403 and atom/tabs#439, but really the tab bar shouldn't be
focusable in the first place. Making this adjustment means we no longer
have to delay the activation of the item and pane (atom/tabs#150 and
atom/tabs#tabs#439) since the focus will no longer be given to the tab
bar as part of the default action of the mousedown handler.

This shouldn't be merged until after 1.17 leaves beta. For the 1.17 beta, atom/atom#14403 and atom/tabs#439 are the less invasive fixes.

cc @ungb 