### PR TITLE
Tweak tests so that they work when Pane.close becomes async

### DIFF
--- a/spec/mru-list-spec.coffee
+++ b/spec/mru-list-spec.coffee
@@ -28,13 +28,19 @@ describe 'MRU List', ->
       pane.splitDown()
       expect(workspaceElement.querySelectorAll('.tabs-mru-switcher').length).toBe initialPaneCount + 2
 
-      pane = atom.workspace.getActivePane()
-      pane.close()
-      expect(workspaceElement.querySelectorAll('.tabs-mru-switcher').length).toBe initialPaneCount + 1
+      waitsForPromise ->
+        pane = atom.workspace.getActivePane()
+        Promise.resolve(pane.close())
 
-      pane = atom.workspace.getActivePane()
-      pane.close()
-      expect(workspaceElement.querySelectorAll('.tabs-mru-switcher').length).toBe initialPaneCount
+      runs ->
+        expect(workspaceElement.querySelectorAll('.tabs-mru-switcher').length).toBe initialPaneCount + 1
+
+      waitsForPromise ->
+        pane = atom.workspace.getActivePane()
+        Promise.resolve(pane.close())
+
+      runs ->
+        expect(workspaceElement.querySelectorAll('.tabs-mru-switcher').length).toBe initialPaneCount
 
     it "Doesn't build list until activated for the first time", ->
       expect(workspaceElement.querySelectorAll('.tabs-mru-switcher').length).toBe initialPaneCount

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -722,8 +722,9 @@ describe "TabBarView", ->
         tab2 = tabBar2.tabAtIndex(0)
         spyOn(tab2, 'destroy')
 
-        pane2.close()
-        expect(tab2.destroy).toHaveBeenCalled()
+        waitsForPromise ->
+          Promise.resolve(pane2.close()).then ->
+            expect(tab2.destroy).toHaveBeenCalled()
 
   describe "dragging and dropping tabs", ->
     describe "when a tab is dragged within the same pane", ->


### PR DESCRIPTION
The `TextBuffer.save` method is going to become async in atom/atom#14435; instead of doing a synchronous write, it will initiate an asynchronous write and return a promise when the write completes. As a result, a few methods that depend on saving the buffer (like `Pane.close`, which is private) are now async as well. This shouldn't affect the user-facing functionality of many packages; but several packages may have test failures.

This PR updates the two tests in `tabs` that broke due to this change, so that they work regardless of whether save is synchronous or asynchronous.