### PR TITLE
Fix handling of dragging pane items over tab bars

### DIFF
--- a/lib/layout.coffee
+++ b/lib/layout.coffee
@@ -1,7 +1,7 @@
 module.exports =
   activate: ->
     @view = document.createElement 'div'
-    atom.views.getView(atom.workspace).appendChild @view
+    atom.workspace.getElement().appendChild @view
     @view.classList.add 'tabs-layout-overlay'
 
   deactivate: ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -62,7 +62,7 @@ module.exports =
           mruListView = new MRUListView
           mruListView.initialize(pane)
 
-          paneElement = atom.views.getView(pane)
+          paneElement = pane.getElement()
           paneElement.insertBefore(tabBarView.element, paneElement.firstChild)
 
           @tabBarViews.push(tabBarView)

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -19,7 +19,7 @@ class TabBarView
     @tabsByElement = new WeakMap
     @subscriptions = new CompositeDisposable
 
-    @subscriptions.add atom.commands.add atom.views.getView(@pane),
+    @subscriptions.add atom.commands.add @pane.getElement(),
       'tabs:keep-pending-tab': => @terminatePendingStates()
       'tabs:close-tab': => @closeTab(@getActiveTab())
       'tabs:close-other-tabs': => @closeOtherTabs(@getActiveTab())
@@ -457,7 +457,7 @@ class TabBarView
       @isItemMovingBetweenPanes = false
 
   removeDropTargetClasses: ->
-    workspaceElement = atom.views.getView(atom.workspace)
+    workspaceElement = atom.workspace.getElement()
     for dropTarget in workspaceElement.querySelectorAll('.tab-bar .is-drop-target')
       dropTarget.classList.remove('is-drop-target')
 

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -14,6 +14,7 @@ class TabBarView
     @element.classList.add("inset-panel")
     @element.setAttribute('is', 'atom-tabs')
     @element.setAttribute("tabindex", -1)
+    @element.setAttribute("location", @location)
 
     @tabs = []
     @tabsByElement = new WeakMap

--- a/spec/file-icons-spec.coffee
+++ b/spec/file-icons-spec.coffee
@@ -5,7 +5,7 @@ describe 'file icon handling', ->
   workspaceElement = null
 
   beforeEach ->
-    workspaceElement = atom.views.getView(atom.workspace)
+    workspaceElement = atom.workspace.getElement()
 
     waitsForPromise ->
       atom.workspace.open('sample.js')

--- a/spec/mru-list-spec.coffee
+++ b/spec/mru-list-spec.coffee
@@ -6,7 +6,7 @@ describe 'MRU List', ->
   workspaceElement = null
 
   beforeEach ->
-    workspaceElement = atom.views.getView(atom.workspace)
+    workspaceElement = atom.workspace.getElement()
 
     waitsForPromise ->
       atom.workspace.open('sample.js')

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -23,7 +23,7 @@ describe "Tabs package main", ->
   centerElement = null
 
   beforeEach ->
-    centerElement = atom.views.getView(getCenter().paneContainer)
+    centerElement = getCenter().paneContainer.getElement()
 
     waitsForPromise ->
       atom.workspace.open('sample.js')
@@ -545,7 +545,7 @@ describe "TabBarView", ->
 
   describe "context menu commands", ->
     beforeEach ->
-      paneElement = atom.views.getView(pane)
+      paneElement = pane.getElement()
       paneElement.insertBefore(tabBar.element, paneElement.firstChild)
 
     describe "when tabs:close-tab is fired", ->
@@ -667,8 +667,7 @@ describe "TabBarView", ->
     paneElement = null
 
     beforeEach ->
-      paneElement = atom.views.getView(pane)
-
+      paneElement = pane.getElement()
 
     describe "when tabs:close-tab is fired", ->
       it "closes the active tab", ->
@@ -884,7 +883,7 @@ describe "TabBarView", ->
         tab = tabBar.tabAtIndex(2).element
         layout.test =
           pane: pane
-          itemView: atom.views.getView(pane).querySelector('.item-views')
+          itemView: pane.getElement().querySelector('.item-views')
           rect: {top: 0, left: 0, width: 100, height: 100}
 
         expect(layout.view.classList.contains('visible')).toBe(false)
@@ -903,7 +902,7 @@ describe "TabBarView", ->
         tab = tabBar.tabAtIndex(2).element
         layout.test =
           pane: pane
-          itemView: atom.views.getView(pane).querySelector('.item-views')
+          itemView: pane.getElement().querySelector('.item-views')
           rect: {top: 0, left: 0, width: 100, height: 100}
 
         tab.ondrag target: tab, clientX: 80, clientY: 50
@@ -920,7 +919,7 @@ describe "TabBarView", ->
           tab = tabBar.tabAtIndex(0).element
           layout.test =
             pane: pane
-            itemView: atom.views.getView(pane).querySelector('.item-views')
+            itemView: pane.getElement().querySelector('.item-views')
             rect: {top: 0, left: 0, width: 100, height: 100}
 
           tab.ondrag target: tab, clientX: 80, clientY: 50
@@ -936,7 +935,7 @@ describe "TabBarView", ->
           tab = tabBar.tabAtIndex(2).element
           layout.test =
             pane: toPane
-            itemView: atom.views.getView(toPane).querySelector('.item-views')
+            itemView: toPane.getElement().querySelector('.item-views')
             rect: {top: 0, left: 0, width: 100, height: 100}
 
           tab.ondrag target: tab, clientX: 80, clientY: 50
@@ -1033,7 +1032,7 @@ describe "TabBarView", ->
         [pane2, tabBar2, dockItem] = []
 
         beforeEach ->
-          jasmine.attachToDOM(atom.views.getView(atom.workspace))
+          jasmine.attachToDOM(atom.workspace.getElement())
           pane = atom.workspace.getActivePane()
           pane2 = atom.workspace.getLeftDock().getActivePane()
           dockItem = new TestView('Dock Item')
@@ -1222,7 +1221,7 @@ describe "TabBarView", ->
           runs ->
             pane.activateItem(editor1)
             expect(isPending(editor1)).toBe true
-            atom.commands.dispatch(atom.views.getView(atom.workspace.getActivePane()), 'tabs:keep-pending-tab')
+            atom.commands.dispatch(atom.workspace.getActivePane().getElement(), 'tabs:keep-pending-tab')
             expect(isPending(editor1)).toBe false
 
       describe "when there is a temp tab already", ->

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -40,7 +40,9 @@ describe "Tabs package main", ->
       pane.splitRight()
 
       expect(centerElement.querySelectorAll('.pane').length).toBe 2
-      expect(centerElement.querySelectorAll('.pane > .tab-bar').length).toBe 2
+      tabBars = centerElement.querySelectorAll('.pane > .tab-bar')
+      expect(tabBars.length).toBe 2
+      expect(tabBars[1].getAttribute('location')).toBe('center')
 
   describe ".deactivate()", ->
     it "removes all tab bar views and stops adding them to new panes", ->


### PR DESCRIPTION
In order to add a tab bar to every pane, we iterate over every pane container on startup and call `observePanes`. Previously, every callback passed to `PaneContainer.observePanes` captured the same `location` variable from its containing scope. This caused every `TabBarView` created after startup to have its `location` set to `bottom` (the final value of the `location` variable).

This bug became more apparent after we disallowed putting TextEditors in Docks, because it meant that you couldn't drag editors between panes: TextEditors are only allowed in the `center` location, but every `TabBarView` thought it was in the `bottom` location.

I've adjusted the aforementioned code to iterate over the pane containers using `Array.forEach` so that we avoid sharing variables between the pane containers' `observePanes` callback.

Also, while I was here, I got rid of some usages of the old `atom.views.getView` API.

Refs https://github.com/atom/tabs/pull/424

/cc @matthewwithanm 