### PR TITLE
[RFC] Add layout to fit mode ala Sublime

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
       "default": true,
       "description": "Show the tab bar even when only one tab is open."
     },
+    "layoutToFit": {
+      "type": "boolean",
+      "default": "false",
+      "description": "Stack tabs so they always fit ala Sublime Text."
+    },
     "tabScrolling": {
       "type": "any",
       "enum": [

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -8,6 +8,27 @@
   -webkit-user-select: none;
   margin: 0;
 
+  &.tab-bar-fitted {
+    position: relative;
+    display: block;
+    overflow: hidden;
+
+    .tab {
+      position: absolute;
+
+      /* TODO: This should be handled by theme */
+      border-right: 1px solid #181a1f;
+
+      &:hover .close-icon {
+        display: none;
+      }
+
+      &.active {
+        width: initial;
+      }
+    }
+  }
+
   .tab {
     font-size: 11px;
     position: relative;


### PR DESCRIPTION
### Requirements

Tests TBD

There are 2 Todos, feedback would be appreciated.

### Description of the Change

Support stacking of tabs in the tab bar ala Sublime Text. When in this new mode, we listen on mousewheel, keeping track of the virtual scroll position. We update each tabs absolute position. We make sure that the layouting is redone on any resize (window resize, dock resizing by drag, pane resizing by drag, opening child panes, closing child panes; opening/closing of docks cannot be supported atm. as there is no event for them). Also preserves the "show active tab on selection behavior" (same way as in Sublime). Also preserves drag and drop behavior (anywhere, including at the stacked ends).

<img width="742" alt="screen shot 2017-06-26 at 23 30 32" src="https://user-images.githubusercontent.com/1473433/27563781-9062b53e-5acb-11e7-93d3-fa8f555a58c0.png">

### Alternate Designs

Maybe as a separate package? Not sure if that is doable though.

This doesn't implement Sublime's gradual decreasing of the shown offset of each tab, the advantage is that if your active item's tab is far on either side, it will still be visible. The downside is that the sides take up more space (at least that still incentivizes you to close your tabs eventually).

### Benefits

The current implementation of the tab bar is pretty useless if you have long file names. Additionally if you have many tabs open (even with short names), and you scroll the tab bar away, you lose the active item's tab (which you might hold as a "mental position" from which you find other tabs). With this behavior, you can always find the tab for the active item, plus you always see how many tabs you have open in total, and you always see the tabs' full names.

### Possible Drawbacks

There is one more option now (the one that enables/disables this mode). Perf-wise this change should be negligible (and enabled runs smoothly at least on my machine).

### Applicable Issues

Fixes #136

