### PR TITLE
Provide service API

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -87,7 +87,8 @@ module.exports =
       @updateFileIcons()
 
   provideTabs: ->
-    @tabBarViews
+    isTab: (target) -> target.closest(".tab-bar > .tab")?
+    getPath: (target) -> target.closest(".tab-bar > .tab")?.querySelector(".title")?.dataset?.path
 
   updateFileIcons: ->
     for tabBarView in @tabBarViews

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -86,6 +86,9 @@ module.exports =
       FileIcons.resetService()
       @updateFileIcons()
 
+  provideTabs: ->
+    @tabBarViews
+
   updateFileIcons: ->
     for tabBarView in @tabBarViews
       tabView.updateIcon() for tabView in tabBarView.getTabs()

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "providedServices": {
     "tabs": {
-      "description": "Get tabs info",
+      "description": "Get tab info",
       "versions": {
         "1.0.0": "provideTabs"
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,14 @@
       }
     }
   },
+  "provideServices": {
+    "tabs": {
+      "description": "Get tabs info",
+      "versions": {
+        "1.0.0": "provideTabs"
+      }
+    }
+  },
   "configSchema": {
     "showIcons": {
       "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       }
     }
   },
-  "provideServices": {
+  "providedServices": {
     "tabs": {
       "description": "Get tabs info",
       "versions": {


### PR DESCRIPTION
### Description of the Change

Provided a service that lets other packages get the path of a context target in a standard way.

At the moment any package that interacts with the tabs package to get files or other information are doing so by getting the active package's `mainModule` or checking classes and data attributes on elements.

There is a standard way to get this information through the [Services API](http://flight-manual.atom.io/behind-atom/sections/interacting-with-other-packages-via-services/)

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

We may want to change what actually gets provided.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Other packages can interact with this package in a standard way.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

none

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues


<!-- Enter any applicable Issues here -->
