### PR TITLE
Perform left/middle click actions on `click` instead of on `mousedown`

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -86,6 +86,7 @@ class TabBarView
     @updateActiveTab()
 
     @element.addEventListener "mousedown", @onMouseDown.bind(this)
+    @element.addEventListener "click", @onClick.bind(this)
     @element.addEventListener "dblclick", @onDoubleClick.bind(this)
 
     @onDropOnOtherWindow = @onDropOnOtherWindow.bind(this)
@@ -404,18 +405,21 @@ class TabBarView
       @rightClickedTab = tab
       @rightClickedTab.element.classList.add('right-clicked')
       event.preventDefault()
+
+  onClick: (event) ->
+    tab = @tabForElement(event.target)
+    return unless tab
+
+    event.preventDefault()
+    if event.which is 3 or (event.which is 1 and event.ctrlKey is true)
+      # Bail out early when receiving this event, because we have already
+      # handled it in the mousedown handler.
+      return
     else if event.which is 1 and not event.target.classList.contains('close-icon')
-      # Delay action. This is important because the browser will set the focus
-      # as part of the default action of the mousedown event; therefore, any
-      # change we make to the focus as part of the handler would be overwritten.
-      # We could use `preventDefault()` to address this, but that would also
-      # make the tab undraggable.
-      setImmediate =>
-        @pane.activateItem(tab.item)
-        @pane.activate() unless @pane.isDestroyed()
+      @pane.activateItem(tab.item)
+      @pane.activate() unless @pane.isDestroyed()
     else if event.which is 2
       @pane.destroyItem(tab.item)
-      event.preventDefault()
 
   onDoubleClick: (event) ->
     if tab = @tabForElement(event.target)

--- a/spec/event-helpers.coffee
+++ b/spec/event-helpers.coffee
@@ -12,6 +12,19 @@ module.exports.triggerMouseEvent = (type, target, {which, ctrlKey}={}) ->
   target.dispatchEvent(event)
   event
 
+module.exports.triggerClickEvent = (target, options) ->
+  events = {
+    mousedown: buildMouseEvent('mousedown', target, options),
+    mouseup: buildMouseEvent('mouseup', target, options),
+    click: buildMouseEvent('click', target, options)
+  }
+
+  target.dispatchEvent(events.mousedown)
+  target.dispatchEvent(events.mouseup)
+  target.dispatchEvent(events.click)
+
+  events
+
 module.exports.buildDragEvents = (dragged, dropTarget) ->
   dataTransfer =
     data: {}


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/15197
Fixes #198 
Supersedes and closes #385

Other than simplifying the code (we don't need to schedule a `setImmediate` callback to focus the item corresponding to the clicked tab), this pull-request also serves as a workaround to a Chromium bug that blocks the UI thread when middle-clicking a tab on Linux and showing a message box in the handler.

Using `click` slightly changes the UX, because left and middle click actions will be performed when users actually end the click action, rather than when they start it. Chrome, Safari and the macOS UI all behave this way, so I believe this is a good tradeoff from a user-experience standpoint.

Please, note that we still need to handle the right-click event via a `mousedown` handler, because Chromium does not seem to fire `click`events when opening context menus.

@matthewwithanm: I saw you introduced the `setImmediate` scheduling for focus reasons. With these changes, pane activation seem to exhibit the correct behavior, so I went ahead and deleted that workaround. However, I'd ❤️ to get your feedback on this in case you think it's not quite we want.

@Ben3eeE @ungb @50Wliu: as mentioned above, this slightly changes the UX and rearranges the way we respond to mouse input events in tabs. Can you help me test this doesn't regress any unrelated feature? In particular, it may be good to test all the mouse interactions on the various platforms and ensure everything works as expected. I performed some tests on Ubuntu and macOS, but some more QA on this would be super appreciated. ✨ 

/cc: @nathansobo for 👀 