### PR TITLE
Don't activate scroll-mode on middle-click when some tabs are off-screen

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -405,6 +405,10 @@ class TabBarView
       @rightClickedTab = tab
       @rightClickedTab.element.classList.add('right-clicked')
       event.preventDefault()
+    else if event.which is 2
+      # This prevents Chromium from activating "scroll mode" when
+      # middle-clicking while some tabs are off-screen.
+      event.preventDefault()
 
   onClick: (event) ->
     tab = @tabForElement(event.target)


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/15471

Before:

![before](https://user-images.githubusercontent.com/482957/29819821-90c347f4-8cc2-11e7-926b-b907e79a8620.gif)

After:

![after](https://user-images.githubusercontent.com/482957/29819822-90e4cfe6-8cc2-11e7-9416-aa277ae50122.gif)

/cc: @iolsen @ungb