### PR TITLE
Don't try to copy items by serializing and deserializing them

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -196,11 +196,8 @@ class TabBarView
 
   splitTab: (fn) ->
     if item = @rightClickedTab?.item
-      if copiedItem = @copyItem(item)
+      if copiedItem = item.copy?()
         @pane[fn](items: [copiedItem])
-
-  copyItem: (item) ->
-    item.copy?() ? atom.deserializers.deserialize(item.serialize())
 
   closeOtherTabs: (active) ->
     tabs = @getTabs()


### PR DESCRIPTION
Fixes https://github.com/atom/tabs/issues/234

Previously, when splitting an item using its tab's context menu, if the item did not have a `.copy()` method, we would try to copy the item by serializing it and then deserializing the serialized state. The problem with this is that for some items (e.g. [the tree-view](https://github.com/atom/tree-view/blob/e33e6c98616061778a0d7c8610b9d26737e61f8c/lib/tree-view-package.js#L55-L61)), deserialization always returns the same instance.

I think it's more explicit for copyable items to just implement a `.copy()` method. Before releasing this change, I need to add a `.copy` method to some of Atom's pane item classes:

* [x] Image View (https://github.com/atom/image-view/commit/9bf5e2649476abbf24d44fe53baf8837dbd037d6)
* [x] Archive View (https://github.com/atom/archive-view/commit/8d14cdae15f658c0f16633115c9c68241b9dcce5)