### PR TITLE
Improve MRU tab list display

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -13,7 +13,7 @@ module.exports =
     @mruListViews = []
 
     keyBindSource = 'tabs package'
-    configKey = 'tabs.enableMruTabSwitching'
+    enableMruConfigKey = 'tabs.enableMruTabSwitching'
 
     @updateTraversalKeybinds = ->
       # We don't modify keybindings based on our setting if the user has already tweaked them.
@@ -26,7 +26,7 @@ module.exports =
         keystrokes: 'ctrl-shift-tab')
       return if bindings.length > 1 and bindings[0].source isnt keyBindSource
 
-      if atom.config.get(configKey)
+      if atom.config.get(enableMruConfigKey)
         atom.keymaps.removeBindingsFromSource(keyBindSource)
       else
         disabledBindings =
@@ -37,7 +37,7 @@ module.exports =
             'ctrl-shift-tab ^ctrl': 'unset!'
         atom.keymaps.add(keyBindSource, disabledBindings, 0)
 
-    @subscriptions.add atom.config.observe configKey, => @updateTraversalKeybinds()
+    @subscriptions.add atom.config.observe enableMruConfigKey, => @updateTraversalKeybinds()
     @subscriptions.add atom.keymaps.onDidLoadUserKeymap? => @updateTraversalKeybinds()
 
     # If the command bubbles up without being handled by a particular pane,

--- a/lib/mru-list-view.js
+++ b/lib/mru-list-view.js
@@ -3,6 +3,8 @@
 import MRUItemView from './mru-item-view'
 import {CompositeDisposable} from 'atom'
 
+const displayListConfigKey = 'tabs.displayMruTabList'
+
 export default class MRUListView {
   initialize (pane) {
     this.ownerDiv = document.createElement('div')
@@ -19,12 +21,17 @@ export default class MRUListView {
     })
     this.element.classList.add('list-group')
 
+    this.displayMruList = atom.config.get(displayListConfigKey)
     this.hideClickHandler = this.hide.bind(this)
     this.preventPropagationClickHandler = this.preventPropagation.bind(this)
   }
 
   subscribe () {
     this.subscriptions = new CompositeDisposable()
+
+    this.subscriptions.add(atom.config.observe(
+      displayListConfigKey,
+      (newValue) => this.displayMruList = newValue))
 
     /* Check for existence of events. Allows package tests to pass until this
     change hits stable. */
@@ -59,13 +66,17 @@ export default class MRUListView {
   }
 
   choose (selectedItem) {
-    this.pendingShow = true;
-    this.show(selectedItem)
+    if (this.displayMruList) {
+      this.pendingShow = true;
+      this.show(selectedItem)
+    }
   }
 
   stopChoosing () {
-    this.pendingShow = false;
-    this.hide()
+    if (this.displayMruList) {
+      this.pendingShow = false;
+      this.hide()
+    }
   }
 
   show (selectedItem) {
@@ -79,7 +90,7 @@ export default class MRUListView {
         this.panel.show()
         this.addClickHandlers()
         this.scrollToItemView(selectedViewElement)
-      }, 100)
+      }, 150)
     } else {
       selectedViewElement = this.updateSelectedItem(selectedItem)
       this.scrollToItemView(selectedViewElement)

--- a/lib/mru-list-view.js
+++ b/lib/mru-list-view.js
@@ -31,7 +31,7 @@ export default class MRUListView {
 
     this.subscriptions.add(atom.config.observe(
       displayListConfigKey,
-      (newValue) => this.displayMruList = newValue))
+      (newValue) => (this.displayMruList = newValue)))
 
     /* Check for existence of events. Allows package tests to pass until this
     change hits stable. */

--- a/lib/mru-list-view.js
+++ b/lib/mru-list-view.js
@@ -11,6 +11,7 @@ export default class MRUListView {
     this.ownerDiv.classList.add('select-list', 'tabs-mru-switcher')
 
     this.pane = pane
+    this.pendingShow = false;
     this.subscribe()
     this.panel = atom.workspace.addModalPanel({
       item: this.ownerDiv,
@@ -58,23 +59,31 @@ export default class MRUListView {
   }
 
   choose (selectedItem) {
+    this.pendingShow = true;
     this.show(selectedItem)
   }
 
   stopChoosing () {
+    this.pendingShow = false;
     this.hide()
   }
 
   show (selectedItem) {
     let selectedViewElement
     if (!this.panel.visible) {
-      selectedViewElement = this.buildListView(selectedItem)
-      this.panel.show()
-      this.addClickHandlers()
+      window.setTimeout(() =>
+      {
+        if (!this.pendingShow)
+          return
+        selectedViewElement = this.buildListView(selectedItem)
+        this.panel.show()
+        this.addClickHandlers()
+        this.scrollToItemView(selectedViewElement)
+      }, 100)
     } else {
       selectedViewElement = this.updateSelectedItem(selectedItem)
+      this.scrollToItemView(selectedViewElement)
     }
-    this.scrollToItemView(selectedViewElement)
   }
 
   preventPropagation () {

--- a/lib/mru-list-view.js
+++ b/lib/mru-list-view.js
@@ -13,7 +13,7 @@ export default class MRUListView {
     this.ownerDiv.classList.add('select-list', 'tabs-mru-switcher')
 
     this.pane = pane
-    this.pendingShow = false;
+    this.pendingShow = false
     this.subscribe()
     this.panel = atom.workspace.addModalPanel({
       item: this.ownerDiv,
@@ -67,14 +67,14 @@ export default class MRUListView {
 
   choose (selectedItem) {
     if (this.displayMruList) {
-      this.pendingShow = true;
+      this.pendingShow = true
       this.show(selectedItem)
     }
   }
 
   stopChoosing () {
     if (this.displayMruList) {
-      this.pendingShow = false;
+      this.pendingShow = false
       this.hide()
     }
   }
@@ -82,10 +82,8 @@ export default class MRUListView {
   show (selectedItem) {
     let selectedViewElement
     if (!this.panel.visible) {
-      window.setTimeout(() =>
-      {
-        if (!this.pendingShow)
-          return
+      window.setTimeout(() => {
+        if (!this.pendingShow) return
         selectedViewElement = this.buildListView(selectedItem)
         this.panel.show()
         this.addClickHandlers()

--- a/package.json
+++ b/package.json
@@ -62,6 +62,12 @@
       "title": "Enable MRU Tab Switching",
       "default": true,
       "description": "Enable tab switching in most-recently-used order. This setting has no effect if ctrl-tab or ctrl-shift-tab are already rebound via your keymap or another package."
+    },
+    "displayMruTabList": {
+      "type": "boolean",
+      "title": "Display MRU Tab Switching List",
+      "default": true,
+      "description": "When MRU Tab Switching is enabled, display the most-recently-used tab list."
     }
   },
   "devDependencies": {

--- a/spec/mru-list-spec.coffee
+++ b/spec/mru-list-spec.coffee
@@ -53,11 +53,19 @@ describe 'MRU List', ->
 
   describe "contents", ->
     pane = null
+    realSetTimeout = window.setTimeout
 
     beforeEach ->
+      # The MRU tab list is deliberately delayed before display.
+      # Here we mock window.setTimeout rather than introducing a corresponding delay in tests
+      # because faster tests are better.
+      jasmine.getGlobal().setTimeout = (callback, wait) => callback()
       waitsForPromise ->
         atom.workspace.open("sample.png")
       pane = atom.workspace.getActivePane()
+
+    afterEach ->
+      jasmine.getGlobal().setTimeout = realSetTimeout
 
     it "has one item per tab", ->
       if pane.onChooseNextMRUItem?

--- a/spec/mru-list-spec.coffee
+++ b/spec/mru-list-spec.coffee
@@ -4,6 +4,8 @@ temp = require('temp').track()
 
 describe 'MRU List', ->
   workspaceElement = null
+  enableMruConfigKey = 'tabs.enableMruTabSwitching'
+  displayMruTabListConfigKey = 'tabs.displayMruTabList'
 
   beforeEach ->
     workspaceElement = atom.workspace.getElement()
@@ -86,8 +88,16 @@ describe 'MRU List', ->
       fourthActiveItem = pane.getActiveItem()
       expect(fourthActiveItem).toBe(firstActiveItem)
 
+    it "disables display when configured to", ->
+      atom.config.set(displayMruTabListConfigKey, false)
+      expect(atom.config.get(displayMruTabListConfigKey)).toBe(false)
+      if pane.onChooseNextMRUItem?
+        expect(pane.getItems().length).toBe 2
+        atom.commands.dispatch(workspaceElement, 'pane:show-next-recently-used-item')
+        expect(workspaceElement.querySelectorAll('.tabs-mru-switcher li').length).toBe 0
+
+
   describe "config", ->
-    configKey = 'tabs.enableMruTabSwitching'
     dotAtomPath = null
 
     beforeEach ->
@@ -100,7 +110,8 @@ describe 'MRU List', ->
       fs.removeSync(dotAtomPath)
 
     it "defaults on", ->
-      expect(atom.config.get(configKey)).toBe(true)
+      expect(atom.config.get(enableMruConfigKey)).toBe(true)
+      expect(atom.config.get(displayMruTabListConfigKey)).toBe(true)
 
       bindings = atom.keymaps.findKeyBindings(
         target: document.body,
@@ -127,7 +138,7 @@ describe 'MRU List', ->
       expect(bindings[0].command).toBe('pane:move-active-item-to-top-of-stack')
 
     it "alters keybindings when disabled", ->
-      atom.config.set(configKey, false)
+      atom.config.set(enableMruConfigKey, false)
       bindings = atom.keymaps.findKeyBindings(
         target: document.body,
         keystrokes: 'ctrl-tab')

--- a/spec/mru-list-spec.coffee
+++ b/spec/mru-list-spec.coffee
@@ -96,7 +96,6 @@ describe 'MRU List', ->
         atom.commands.dispatch(workspaceElement, 'pane:show-next-recently-used-item')
         expect(workspaceElement.querySelectorAll('.tabs-mru-switcher li').length).toBe 0
 
-
   describe "config", ->
     dotAtomPath = null
 


### PR DESCRIPTION
Two MRU display related improvements:

- a 150ms delay before showing the MRU tab list as suggested in #361 
- an option to disable display of the list altogether as previously attempted in #422.

<img width="728" alt="mru-list-display-setting" src="https://user-images.githubusercontent.com/553742/31642804-d6e65d66-b2a1-11e7-9162-71ae53c309ba.png">
