### PR TITLE
Remove old function guards

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -38,7 +38,7 @@ module.exports =
         atom.keymaps.add(keyBindSource, disabledBindings, 0)
 
     @subscriptions.add atom.config.observe enableMruConfigKey, => @updateTraversalKeybinds()
-    @subscriptions.add atom.keymaps.onDidLoadUserKeymap? => @updateTraversalKeybinds()
+    @subscriptions.add atom.keymaps.onDidLoadUserKeymap => @updateTraversalKeybinds()
 
     # If the command bubbles up without being handled by a particular pane,
     # close all tabs in all panes
@@ -50,10 +50,10 @@ module.exports =
           tabBarView.closeAllTabs()
 
     paneContainers =
-      center: atom.workspace.getCenter?() ? atom.workspace
-      left: atom.workspace.getLeftDock?()
-      right: atom.workspace.getRightDock?()
-      bottom: atom.workspace.getBottomDock?()
+      center: atom.workspace.getCenter()
+      left: atom.workspace.getLeftDock()
+      right: atom.workspace.getRightDock()
+      bottom: atom.workspace.getBottomDock()
 
     Object.keys(paneContainers).forEach (location) =>
       container = paneContainers[location]

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -52,17 +52,8 @@ class TabView
       @updateTitle()
 
     @subscriptions.add @pane.onDidDestroy => @destroy()
-
-    # TODO: remove else condition once pending API is on stable [MKT]
-    if typeof @pane.onItemDidTerminatePendingState is 'function'
-      @subscriptions.add @pane.onItemDidTerminatePendingState (item) =>
-        @clearPending() if item is @item
-    else if typeof @item.onDidTerminatePendingState is 'function'
-      onDidTerminatePendingStateDisposable = @item.onDidTerminatePendingState => @clearPending()
-      if Disposable.isDisposable(onDidTerminatePendingStateDisposable)
-        @subscriptions.add(onDidTerminatePendingStateDisposable)
-      else
-        console.warn "::onDidTerminatePendingState does not return a valid Disposable!", @item
+    @subscriptions.add @pane.onItemDidTerminatePendingState (item) =>
+      @clearPending() if item is @item
 
     if typeof @item.onDidChangeTitle is 'function'
       onDidChangeTitleDisposable = @item.onDidChangeTitle(titleChangedHandler)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": "https://github.com/atom/tabs",
   "engines": {
-    "atom": "*"
+    "atom": ">=1.17.0"
   },
   "dependencies": {
     "fs-plus": "^3.0.0",


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

These guards were put into place as new features were added to Atom but not yet available on stable. All the features are now in stable Atom, so the guards can be removed.

### Alternate Designs

None.

### Benefits

Less unnecessary conditionals.

### Possible Drawbacks

tabs will stop working on Atom versions less than 1.17.

### Applicable Issues

None, but helps a little with #548