### PR TITLE
Don't create a split if the tab cannot be placed in the pane

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -18,7 +18,7 @@ module.exports = {
     const pane = this.getPaneAt(e)
     const itemView = this.getItemViewAt(e)
     const {item} = e.target
-    if (pane && itemView && item && itemIsAllowedInPane(item, pane)) {
+    if (pane && itemView && item && this.itemIsAllowedInPane(item, pane)) {
       let coords
       if (!this.isOnlyTabInPane(pane, e.target) && pane.getItems().length !== 0) {
         coords = [e.clientX, e.clientY]
@@ -44,7 +44,7 @@ module.exports = {
     const fromPane = tab.pane
     const {item} = tab
 
-    if (!itemIsAllowedInPane(item, target)) {
+    if (!this.itemIsAllowedInPane(item, target)) {
       return
     }
 
@@ -152,23 +152,23 @@ module.exports = {
 
   disableView () {
     this.view.classList.remove('visible')
-  }
-}
+  },
 
-const itemIsAllowedInPane = (item, pane) => {
-  if (typeof item.getAllowedLocations === 'function') {
-    const allowedLocations = item.getAllowedLocations()
-    if (allowedLocations == null) {
-      return true
+  itemIsAllowedInPane (item, pane) {
+    if (typeof item.getAllowedLocations === 'function') {
+      const allowedLocations = item.getAllowedLocations()
+      if (allowedLocations == null) {
+        return true
+      }
+
+      const container = pane.getContainer()
+      let location = 'center'
+      if (typeof container.getLocation === 'function') {
+        location = container.getLocation() || 'center'
+      }
+
+      return allowedLocations.includes(location)
     }
-
-    const container = pane.getContainer()
-    let location = 'center'
-    if (typeof container.getLocation === 'function') {
-      location = container.getLocation() || 'center'
-    }
-
-    return allowedLocations.includes(location)
+    return true
   }
-  return true
 }

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -44,6 +44,10 @@ module.exports = {
     const fromPane = tab.pane
     const {item} = tab
 
+    if (!itemIsAllowedInPane(item, target)) {
+      return
+    }
+
     let toPane
     switch (this.lastSplit) {
       case 'left':
@@ -62,7 +66,7 @@ module.exports = {
         toPane = target
     }
 
-    if (!itemIsAllowedInPane(item, toPane) || toPane === fromPane) {
+    if (toPane === fromPane) {
       return
     }
 

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -947,6 +947,23 @@ describe "TabBarView", ->
           expect(tabBar.getTabs().map (tab) -> tab.element.textContent).toEqual ["Item 1", "sample.js"]
           expect(atom.workspace.getActivePane().getItems().length).toEqual(1)
 
+      describe "when the tab is not allowed in that pane", ->
+        it "does not move the tab, nor does it create a split", ->
+          layout.test =
+            pane: pane
+            itemView: pane.getElement().querySelector('.item-views')
+            rect: {top: 0, left: 0, width: 100, height: 100}
+
+          spyOn(layout, 'itemIsAllowedInPane').andReturn(false)
+          spyOn(pane, 'split')
+
+          tab = tabBar.tabAtIndex(0).element
+          tab.ondrag(target: tab, clientX: 80, clientY: 50)
+          layout.lastSplit = 'left'
+          tab.ondragend(target: tab, clientX: 80, clientY: 50)
+
+          expect(pane.split).not.toHaveBeenCalled()
+
     describe "when a non-tab is dragged to pane", ->
       it "has no effect", ->
         expect(tabBar.getTabs().map (tab) -> tab.element.textContent).toEqual ["Item 1", "sample.js", "Item 2"]


### PR DESCRIPTION
This fixes a regression from #548. The code there was `toPane ? target`, even though `toPane` was always undefined. I mistakenly moved the location check to after `toPane`'s definition, even though we should always be able to look at `target` (as a split will not affect the pane's location).