### PR TITLE
Allow layout tests to be run individually

### DIFF
--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -881,6 +881,13 @@ describe "TabBarView", ->
           atom.config.set("tabs.addNewTabsAtEnd", false)
 
     describe "when a tab is dragged over a pane item", ->
+      beforeEach ->
+        layout.activate()
+
+      afterEach ->
+        layout.deactivate()
+        layout.test = {}
+
       it "draws an overlay over the item", ->
         expect(tabBar.getTabs().map (tab) -> tab.element.textContent).toEqual ["Item 1", "sample.js", "Item 2"]
         tab = tabBar.tabAtIndex(2).element


### PR DESCRIPTION
In #550, I noticed that attempting to focus any of the layout-related specs would fail, because the layout wasn't being activated (it was being activated in some other, unrelated test). This PR handles activation/deactivation of the layout in before/afterEach calls.