### PR TITLE
Fix tab close on middle click for Electron 3

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -87,6 +87,7 @@ class TabBarView
 
     @element.addEventListener "mousedown", @onMouseDown.bind(this)
     @element.addEventListener "click", @onClick.bind(this)
+    @element.addEventListener "auxclick", @onClick.bind(this)
     @element.addEventListener "dblclick", @onDoubleClick.bind(this)
 
     @onDropOnOtherWindow = @onDropOnOtherWindow.bind(this)


### PR DESCRIPTION
### Description of the Problem

When using Atom with Electron 3, a middle click does not close a tab. This happens, because Electron 3 is based on a Chrome version >= 55. Since then, Chrome changed how click events work. Non-primary clicks now fire the event `auxclick` rather than `click`.

See https://developers.google.com/web/updates/2016/10/auxclick and https://developer.mozilla.org/en-US/docs/Web/Events/auxclick for more information on the event.

### Description of the Change

This PR adds the `onClick` handler of TabBarView also as listener to the `auxclick` event.

### Alternate Designs

None

### Benefits

The change fixes the problem for Electron 3 while it does have no effect in Electron 2, since the `auxclick` event never fires in this version. 

This helps with a future migration of Atom to Electron 3 and fixes the issue for unofficial distributions using Electron 3 now.

### Possible Drawbacks

None

### Applicable Issues

fixes atom/tabs#545