### PR TITLE
Make tab scrolling settings work

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -55,6 +55,7 @@ class TabBarView
 
     @element.addEventListener "mouseenter", @onMouseEnter.bind(this)
     @element.addEventListener "mouseleave", @onMouseLeave.bind(this)
+    @element.addEventListener "mousewheel", @onMouseWheel.bind(this)
     @element.addEventListener "dragstart", @onDragStart.bind(this)
     @element.addEventListener "dragend", @onDragEnd.bind(this)
     @element.addEventListener "dragleave", @onDragLeave.bind(this)
@@ -389,7 +390,7 @@ class TabBarView
       atom.focus()
 
   onMouseWheel: (event) ->
-    return if event.shiftKey
+    return if event.shiftKey or not @tabScrolling
 
     @wheelDelta ?= 0
     @wheelDelta += event.wheelDeltaY
@@ -445,12 +446,6 @@ class TabBarView
       @tabScrolling = (process.platform is 'linux')
     else
       @tabScrolling = value
-    @tabScrollingThreshold = atom.config.get('tabs.tabScrollingThreshold')
-
-    if @tabScrolling
-      @element.addEventListener 'mousewheel', @onMouseWheel.bind(this)
-    else
-      @element.removeEventListener 'mousewheel', @onMouseWheel.bind(this)
 
   browserWindowForId: (id) ->
     BrowserWindow ?= require('electron').remote.BrowserWindow

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -80,9 +80,9 @@ class TabBarView
     @subscriptions.add @pane.onDidChangeActiveItem (item) =>
       @updateActiveTab()
 
-    @subscriptions.add atom.config.observe 'tabs.tabScrolling', @updateTabScrolling.bind(this)
-    @subscriptions.add atom.config.observe 'tabs.tabScrollingThreshold', => @updateTabScrollingThreshold()
-    @subscriptions.add atom.config.observe 'tabs.alwaysShowTabBar', => @updateTabBarVisibility()
+    @subscriptions.add atom.config.observe 'tabs.tabScrolling', (value) => @updateTabScrolling(value)
+    @subscriptions.add atom.config.observe 'tabs.tabScrollingThreshold', (value) => @updateTabScrollingThreshold(value)
+    @subscriptions.add atom.config.observe 'tabs.alwaysShowTabBar', (value) => @updateTabBarVisibility(value)
 
     @updateActiveTab()
 
@@ -148,8 +148,8 @@ class TabBarView
     tab.updateTitle() for tab in @getTabs()
     @updateTabBarVisibility()
 
-  updateTabBarVisibility: ->
-    if not atom.config.get('tabs.alwaysShowTabBar') and not @shouldAllowDrag()
+  updateTabBarVisibility: (value) ->
+    if not value and not @shouldAllowDrag()
       @element.classList.add('hidden')
     else
       @element.classList.remove('hidden')
@@ -438,8 +438,8 @@ class TabBarView
       atom.commands.dispatch(@element, 'application:new-file')
       event.preventDefault()
 
-  updateTabScrollingThreshold: ->
-    @tabScrollingThreshold = atom.config.get('tabs.tabScrollingThreshold')
+  updateTabScrollingThreshold: (value) ->
+    @tabScrollingThreshold = value
 
   updateTabScrolling: (value) ->
     if value is 'platform'

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       "description": "Show the tab bar even when only one tab is open."
     },
     "tabScrolling": {
-      "type": "any",
+      "type": ["boolean", "string"],
       "enum": [
         true,
         false,

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -1167,6 +1167,14 @@ describe "TabBarView", ->
           tabBar.element.dispatchEvent(buildWheelPlusShiftEvent(-120))
           expect(pane.getActiveItem()).toBe item2
 
+      describe "when the tabScrolling is changed to false", ->
+        it "does not change the active tab when scrolling", ->
+          atom.config.set("tabs.tabScrolling", false)
+
+          expect(pane.getActiveItem()).toBe item2
+          tabBar.element.dispatchEvent(buildWheelEvent(120))
+          expect(pane.getActiveItem()).toBe item2
+
     describe "when tabScrolling is false in package settings", ->
       beforeEach ->
         atom.config.set("tabs.tabScrolling", false)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Where to even start? The tabScrolling setting uses a mixed enum of booleans and strings, and declares its type as any. This _should_ be fine...except that since settings-view determines the value of a setting by looking at the HTML value, all booleans are coerced to strings. Then `atom.config.set` decides that the new stringified value is not valid as it isn't in the valid list of values for tabScrolling and ignores it. The "fix" is to explicitly declare the enum as having types boolean and string, so that `atom.config.set` will coerce the stringified boolean back to an actual boolean before checking it against the schema...

Oh, and I also fixed being unable to disable tab scrolling after you enabled it without restarting the tabs package, as the event listener wasn't being removed (function equality). The event listener is now always active but only does anything if the tabScrolling setting is enabled.

### Alternate Designs

Fix settings-view, because there's nothing _technically_ wrong with how tabs decided to implement this setting.

### Benefits

Changing the tab scrolling setting through settings-view will work again, and tab scrolling can be disabled on the fly.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #311