### PR TITLE
 Remove tabs correctly when dropped on another window

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -330,7 +330,7 @@ class TabBarView
         else
           tab.element.parentElement.appendChild(placeholder)
 
-  onDropOnOtherWindow: (fromPaneId, fromItemIndex) ->
+  onDropOnOtherWindow: (event, fromPaneId, fromItemIndex) ->
     if @pane.id is fromPaneId
       if itemToRemove = @pane.getItems()[fromItemIndex]
         @pane.destroyItem(itemToRemove)

--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -2,7 +2,6 @@ BrowserWindow = null # Defer require until actually used
 {ipcRenderer} = require 'electron'
 
 {CompositeDisposable} = require 'atom'
-_ = require 'underscore-plus'
 TabView = require './tab-view'
 
 module.exports =

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -1047,18 +1047,26 @@ describe "TabBarView", ->
           expect(dragStartEvent.dataTransfer.getData("text/uri-list")).toEqual "file://#{editor1.getPath()}"
 
     describe "when a tab is dragged to another Atom window", ->
+      beforeEach ->
+        spyOn(pane, 'destroyItem').andCallThrough()
+
       it "closes the tab in the first window and opens the tab in the second window", ->
         [dragStartEvent, dropEvent] = buildDragEvents(tabBar.tabAtIndex(1).element, tabBar.tabAtIndex(0).element)
         tabBar.onDragStart(dragStartEvent)
-        tabBar.onDropOnOtherWindow(pane.id, 1)
+        atom.getCurrentWindow().webContents.send('tab:dropped', pane.id, 1)
 
-        expect(pane.getItems()).toEqual [item1, item2]
-        expect(pane.getActiveItem()).toBe item2
+        # Can't spy on onDropOnOtherWindow since it's binded
+        waitsFor 'dragged pane item to be destroyed', ->
+          pane.destroyItem.callCount is 1
 
-        dropEvent.dataTransfer.setData('from-window-id', tabBar.getWindowId() + 1)
+        runs ->
+          expect(pane.getItems()).toEqual [item1, item2]
+          expect(pane.getActiveItem()).toBe item2
 
-        spyOn(tabBar, 'moveItemBetweenPanes').andCallThrough()
-        tabBar.onDrop(dropEvent)
+          dropEvent.dataTransfer.setData('from-window-id', tabBar.getWindowId() + 1)
+
+          spyOn(tabBar, 'moveItemBetweenPanes').andCallThrough()
+          tabBar.onDrop(dropEvent)
 
         waitsFor ->
           tabBar.moveItemBetweenPanes.callCount > 0
@@ -1072,12 +1080,17 @@ describe "TabBarView", ->
         editor1.setText('I came from another window')
         [dragStartEvent, dropEvent] = buildDragEvents(tabBar.tabAtIndex(1).element, tabBar.tabAtIndex(0).element)
         tabBar.onDragStart(dragStartEvent)
-        tabBar.onDropOnOtherWindow(pane.id, 1)
+        atom.getCurrentWindow().webContents.send('tab:dropped', pane.id, 1)
 
-        dropEvent.dataTransfer.setData('from-window-id', tabBar.getWindowId() + 1)
+        # Can't spy on onDropOnOtherWindow since it's binded
+        waitsFor 'dragged pane item to be destroyed', ->
+          pane.destroyItem.callCount is 1
 
-        spyOn(tabBar, 'moveItemBetweenPanes').andCallThrough()
-        tabBar.onDrop(dropEvent)
+        runs ->
+          dropEvent.dataTransfer.setData('from-window-id', tabBar.getWindowId() + 1)
+
+          spyOn(tabBar, 'moveItemBetweenPanes').andCallThrough()
+          tabBar.onDrop(dropEvent)
 
         waitsFor ->
           tabBar.moveItemBetweenPanes.callCount > 0
@@ -1091,12 +1104,17 @@ describe "TabBarView", ->
 
         [dragStartEvent, dropEvent] = buildDragEvents(tabBar.tabAtIndex(1).element, tabBar.tabAtIndex(0).element)
         tabBar.onDragStart(dragStartEvent)
-        tabBar.onDropOnOtherWindow(pane.id, 1)
+        atom.getCurrentWindow().webContents.send('tab:dropped', pane.id, 1)
 
-        dropEvent.dataTransfer.setData('from-window-id', tabBar.getWindowId() + 1)
+        # Can't spy on onDropOnOtherWindow since it's binded
+        waitsFor 'dragged pane item to be destroyed', ->
+          pane.destroyItem.callCount is 1
 
-        spyOn(tabBar, 'moveItemBetweenPanes').andCallThrough()
-        tabBar.onDrop(dropEvent)
+        runs ->
+          dropEvent.dataTransfer.setData('from-window-id', tabBar.getWindowId() + 1)
+
+          spyOn(tabBar, 'moveItemBetweenPanes').andCallThrough()
+          tabBar.onDrop(dropEvent)
 
         waitsFor ->
           tabBar.moveItemBetweenPanes.callCount > 0


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The method signature for IPC callbacks is [`(event, args...)`](https://electronjs.org/docs/api/ipc-renderer#ipcrendereronchannel-listener), but the tabs package was using `(args...)` instead. This meant that when dropping a tab onto another Atom window, the original tab would _never_ be destroyed as intended.

### Alternate Designs

None.

### Benefits

This fixes a long-standing bug with dropping tabs on other windows, which was not discovered by the tests as they called the callback manually.

### Possible Drawbacks

The specs are a little hacky...since the listener callback is `bind`ed, it's almost impossible to spy on it correctly. So I resorted to spying on a function that the callback calls.

### Applicable Issues

None.