### PR TITLE
Fix subfolder git detection

### DIFF
--- a/lib/mru-item-view.js
+++ b/lib/mru-item-view.js
@@ -1,10 +1,10 @@
 'use babel'
 
+import {Directory} from 'atom'
 import getIconServices from './get-icon-services'
-import path from 'path'
 
 export default class MRUItemView {
-  initialize (listView, item) {
+  async initialize (listView, item) {
     this.listView = listView
     this.item = item
 
@@ -17,7 +17,7 @@ export default class MRUItemView {
       this.itemPath = item.getPath()
     }
 
-    const repo = MRUItemView.repositoryForPath(this.itemPath)
+    const repo = await MRUItemView.repositoryForPath(this.itemPath)
     if (repo != null) {
       const statusIconDiv = document.createElement('div')
       const status = repo.getCachedPathStatus(this.itemPath)
@@ -56,14 +56,9 @@ export default class MRUItemView {
     this.element.classList.remove('selected')
   }
 
-  static repositoryForPath (filePath) {
+  static async repositoryForPath (filePath) {
     if (filePath) {
-      const projectPaths = atom.project.getPaths()
-      for (let i = 0; i < projectPaths.length; i++) {
-        if (filePath === projectPaths[i] || filePath.startsWith(projectPaths[i] + path.sep)) {
-          return atom.project.getRepositories()[i]
-        }
-      }
+      return atom.project.repositoryForDirectory(new Directory(filePath))
     }
     return null
   }

--- a/lib/tab-view.coffee
+++ b/lib/tab-view.coffee
@@ -1,5 +1,5 @@
 path = require 'path'
-{Disposable, CompositeDisposable} = require 'atom'
+{Directory, Disposable, CompositeDisposable} = require 'atom'
 getIconServices = require './get-icon-services'
 
 layout = require './layout'
@@ -263,9 +263,7 @@ class TabView
       @updateVcsStatus(repo)
 
   repoForPath: ->
-    for dir in atom.project.getDirectories()
-      return atom.project.repositoryForDirectory(dir) if dir.contains @path
-    Promise.resolve(null)
+    return atom.project.repositoryForDirectory(new Directory(@path))
 
   # Update the VCS status property of this tab using the repo.
   updateVcsStatus: (repo, status) ->

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -1445,7 +1445,7 @@ describe "TabBarView", ->
             expect(tabBar2.tabForItem(pane2.getActiveItem()).element.querySelector('.title')).not.toHaveClass 'temp'
 
   describe "integration with version control systems", ->
-    [repository, tab, tab1] = []
+    [repository, repositorySpy, tab, tab1] = []
 
     beforeEach ->
       tab = tabBar.tabForItem(editor1)
@@ -1476,7 +1476,7 @@ describe "TabBarView", ->
         callback(event) for callback in @changeStatusesCallbacks ? []
 
       # Mock atom.project to pretend we are working within a repository
-      spyOn(atom.project, 'repositoryForDirectory').andReturn Promise.resolve(repository)
+      repositorySpy = spyOn(atom.project, 'repositoryForDirectory').andReturn Promise.resolve(repository)
 
       atom.config.set "tabs.enableVcsColoring", true
 
@@ -1518,6 +1518,10 @@ describe "TabBarView", ->
         expect(repository.getCachedPathStatus.calls.length).toBe 0
 
       it "does not update status for items not in the repository", ->
+        atom.config.set "tabs.enableVcsColoring", false
+        repositorySpy.andReturn Promise.resolve(null)
+        atom.config.set "tabs.enableVcsColoring", true
+
         tab1.updateVcsStatus.reset()
         repository.emitDidChangeStatuses()
         expect(tab1.updateVcsStatus.calls.length).toEqual 0


### PR DESCRIPTION
# Identify the Bug

Same as https://github.com/atom/tree-view/issues/1366

### Description of the Change

By using atom.project.repositoryForPath function instead of matching the path with added directories, subfolders will get identified.
Made necessary changes to referenced places to handle the async nature of the atom.project.repositoryForPath.

### Alternate Designs

None.

### Possible Drawbacks

Since atom.project.repositoryForPath is an async function, there maybe a little lag when loading file which already has changes.

### Verification Process

TODO

### Release Notes

- Fixed subfolders of project folders not getting detected as git repositories.